### PR TITLE
Http Cleanup, Added Exclude_from_body and added to default config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,8 @@ type Http struct {
 	Split_cookie     bool
 	Real_ip_header   string
 	Include_body_for []string
+	Exclude_body_for []string
+
 }
 
 type Mysql struct {

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -111,8 +111,11 @@ device = "any"
 [http]
 ######
 #Only include the HTTP body if the content-type matches
-# An empty array []  will capture everything
-#Include_body_for=["text/html"]
+# An empty array []  will capture everything ***Warning this will include images as well 
+#Include_body_for=["text/"]
+######
+#Exclude the HTTP body if the content-type matches (Overrides Includes_body_for)
+#Exclude_body_for=["image/"]
 ######
 #Send The Http Headers as a specific field
 #Send_all_headers=true

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -111,6 +111,7 @@ device = "any"
 [http]
 ######
 #Only include the HTTP body if the content-type matches
+# An empty array []  will capture everything
 #Include_body_for=["text/html"]
 ######
 #Send The Http Headers as a specific field

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -52,7 +52,9 @@ device = "any"
 # configuration.
   [protocols.http]
   ports = [80, 8080, 8000, 5000, 8002]
+  ## Include the actual request: For Http this will only include the Headers of the request- See the Http section for finer controler
   #send_request=false
+  ## Include the acutal response: For Http this will only include the Heards of the response - See the Http Sections for finer controle
   #send_response=false
 
   [protocols.mysql]
@@ -107,9 +109,17 @@ device = "any"
 #hide_keywords = ["pass", "password", "passwd"]
 
 [http]
+######
+#Only include the HTTP body if the content-type matches
 #Include_body_for=["text/html"]
+######
+#Send The Http Headers as a specific field
 #Send_all_headers=true
+######
+#Remove the HTTP Authentication header
 #Strip_authorization=false
+######
+#Split All cookies to their own field
 #Split_cookie=true
 
 # vim: set ft=toml:

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -52,6 +52,8 @@ device = "any"
 # configuration.
   [protocols.http]
   ports = [80, 8080, 8000, 5000, 8002]
+  #send_request=false
+  #send_response=false
 
   [protocols.mysql]
   ports = [3306]
@@ -103,5 +105,11 @@ device = "any"
 # This is generally useful for avoiding storing user passwords or other
 # sensitive information.
 #hide_keywords = ["pass", "password", "passwd"]
+
+[http]
+#Include_body_for=["text/html"]
+#Send_all_headers=true
+#Strip_authorization=false
+#Split_cookie=true
 
 # vim: set ft=toml:

--- a/protos/http/http.go
+++ b/protos/http/http.go
@@ -135,7 +135,7 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 		http.Send_response = config.Protocols["http"].Send_response
 		logp.Debug("http", "ConfigSetting: protocol.http.Send_response Value: '%t'\n", http.Send_response)
 	}
-	if meta.IsDefined("http", "Include_body_for") {
+	if meta.IsDefined("http", "include_body_for") {
 		http.Include_body_for = config.Http.Include_body_for
 		logp.Debug("http", "ConfigSetting: http.Include_body_for \n")
 		logp.Debug("http", "ConfigSetting: http.Include_body_for Length =%d \n",len(http.Include_body_for))
@@ -143,7 +143,7 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 			logp.Debug("http", "Value: '%s'\n", include)
 		}
 	}
-	if meta.IsDefined("http", "Exclude_body_for") {
+	if meta.IsDefined("http", "exclude_body_for") {
 		http.Exclude_body_for = config.Http.Exclude_body_for
 		logp.Debug("http", "ConfigSetting: http.Exclude_body_for \n")
 		logp.Debug("http", "ConfigSetting: http.Exclude_body_for Length =%d \n",len(http.Exclude_body_for))
@@ -151,23 +151,22 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 			logp.Debug("http", "Value: '%s'\n", include)
 		}
 	}
-	if meta.IsDefined("http", "Hide_keywords") {	
+	if meta.IsDefined("passwords", "hide_keywords") {	
 		http.Hide_keywords = config.Passwords.Hide_keywords
-		logp.Debug("http", "ConfigSetting: http.Hide_keywords Value: '%t'\n", http.Hide_keywords)
+		logp.Debug("http", "ConfigSetting: passwords.hide_keywords Value: '%t'\n", http.Hide_keywords)
 	}
-	if meta.IsDefined("Passwords", "Strip_authorization") {	
+	if meta.IsDefined("passwords", "strip_authorization") {	
 		http.Strip_authorization = config.Passwords.Strip_authorization
-		logp.Debug("http", "ConfigSetting: Password.Strip_authorization Value: '%t'\n", http.Strip_authorization)
+		logp.Debug("http", "ConfigSetting: sassword.strip_authorization Value: '%t'\n", http.Strip_authorization)
 	}
-	if meta.IsDefined("Http", "Send_all_headers") {	
+	if meta.IsDefined("http", "send_all_headers") {	
 		http.Send_headers = true
 		http.Send_all_headers = true
-		http.Strip_authorization = config.Passwords.Strip_authorization
 		logp.Debug("http", "ConfigSetting: Http.Send_all_headers Value: '%t'\n", http.Send_all_headers)
 		logp.Debug("http", "ConfigSetting: Http.Send_headers Value: '%t'\n", http.Send_headers)
 
 	} 
-	if meta.IsDefined("Http", "Send_headers") {	
+	if meta.IsDefined("http", "send_headers") {	
 			http.Send_headers = true
 			logp.Debug("http", "ConfigSetting: Http.Send_headers Value: '%t'\n", http.Send_headers)
 			http.Headers_whitelist = map[string]bool{}
@@ -176,12 +175,12 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 				logp.Debug("http", "ConfigSetting: Http.Headers_whitelist Value: '%s'\n", hdr)
 			}
 	}
-	if meta.IsDefined("Http", "Split_cookie") {	
+	if meta.IsDefined("http", "split_cookie") {	
 		http.Split_cookie = config.Http.Split_cookie
 		logp.Debug("http", "ConfigSetting: Split_cookie Value: '%t'\n", http.Split_cookie)
 	}
-	if meta.IsDefined("Http", "Real_ip_header") {	
-		http.Real_ip_header = config.Http.Real_ip_header
+	if meta.IsDefined("http", "real_ip_header") {	
+		http.Real_ip_header =  strings.ToLower(config.Http.Real_ip_header)
 		logp.Debug("http", "ConfigSetting: Real_ip_header: '%s'\n", http.Real_ip_header)
 	}
 

--- a/protos/http/http.go
+++ b/protos/http/http.go
@@ -110,7 +110,7 @@ type Http struct {
 	Real_ip_header      string
 	Hide_keywords       []string
 	Strip_authorization bool
-	Include_body_for []string
+	Include_body_for 	[]string
 
 	transactionsMap map[common.HashableTcpTuple]*HttpTransaction
 
@@ -120,6 +120,7 @@ type Http struct {
 func (http *Http) InitDefaults() {
 	http.Send_request = false
 	http.Send_response = false
+	http.Include_body_for= nil
 //	http.Include_body_for =  make(map[string]bool)
 //	http.Include_body_for["all"] = false;
 }
@@ -136,6 +137,7 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 	if meta.IsDefined("http", "Include_body_for") {
 		http.Include_body_for = config.Http.Include_body_for
 		logp.Debug("http", "ConfigSetting: http.Include_body_for \n")
+		logp.Debug("http", "ConfigSetting: http.Include_body_for Length =%d \n",len(http.Include_body_for))
 		for _, include := range http.Include_body_for {
 			logp.Debug("http", "Value: '%s'\n", include)
 		}
@@ -858,12 +860,17 @@ func (http *Http) cutMessageBody(m *HttpMessage) []byte {
 }
 
 func (http *Http) shouldIncludeInBody(contenttype string) bool {
-	for _, include := range http.Include_body_for {
-		if strings.Contains(contenttype, include) {
-			logp.Debug("httpdetailed", "Should Include Body = true Content-Type "+contenttype+" http.Include_body_for "+include)
-			return true
+	if http.Include_body_for != nil {
+		if len(http.Include_body_for) == 0{
+			return true;
 		}
-		logp.Debug("httpdetailed", "Should Include Body = false Content-Type"+contenttype+" http.Include_body_for "+include)
+		for _, include := range http.Include_body_for {
+			if strings.Contains(contenttype, include) {
+				logp.Debug("httpdetailed", "Should Include Body = true Content-Type "+contenttype+" http.Include_body_for "+include)
+				return true
+			}
+			logp.Debug("httpdetailed", "Should Include Body = false Content-Type"+contenttype+" http.Include_body_for "+include)
+		}
 	}
 	return false
 }


### PR DESCRIPTION
I noticed that there was no easy way to include all content-type by default, so I added how to empty an empty array Include_body_for=[]

Then I realized if I am including everything I might want to Exclude some things. So I implemented that option too

Someone mentioning that in the issues that some of the options were not documented so I added them to the default config 

Added some extra debug to show which options are getting set
Move Debugging for printing the http body from "http" to "httpdetailed" debug levels

I performed a quick test on the new Include_body_for =[] and Exclude_body_for=["image/"] seems to work well

[http]
Include_body_for=[]
Send_all_headers=true
Strip_authorization=false
Split_cookie=true

Fixed CI issues too