### PR TITLE
Fix typo in gettingstarted doc

### DIFF
--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -300,7 +300,7 @@ cd kibana-4.0.2-darwin-x64/
 You can find Kibana binaries for other operating systems on the
 https://www.elastic.co/downloads/kibana[Kibana downloads page].
 
-If Kibana cannot reach the Elasticsearh server, you can adjust the settings for
+If Kibana cannot reach the Elasticsearch server, you can adjust the settings for
 it from the `config/kibana.yml` file.
 
 Now point your browser to port 5601 and you should see the Kibana web

--- a/docs/gettingstarted.in.asciidoc
+++ b/docs/gettingstarted.in.asciidoc
@@ -291,7 +291,7 @@ cd kibana-$KIBANA_VERSION-darwin-x64/
 You can find Kibana binaries for other operating systems on the
 https://www.elastic.co/downloads/kibana[Kibana downloads page].
 
-If Kibana cannot reach the Elasticsearh server, you can adjust the settings for
+If Kibana cannot reach the Elasticsearch server, you can adjust the settings for
 it from the `config/kibana.yml` file.
 
 Now point your browser to port 5601 and you should see the Kibana web


### PR DESCRIPTION
Just a simple typo fix. I have a signed the contributor agreement.