### PR TITLE
Generate a BPF filter that can skip VLAN tags.

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -236,6 +236,41 @@ interfaces:
   buffer_size_mb: 100
 ------------------------------------------------------------------------------
 
+==== with_vlans
+
+Packetbeat automatically generates a
+https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
+the traffic on the ports on which the known protocols are expected to be found.
+For example, if you have configured port 80 for HTTP and port 3306 for MySQL,
+Packetbeat will generate the following BPF filter: `"port 80 or port 3306"`.
+
+However, if the traffic contains https://en.wikipedia.org/wiki/IEEE_802.1Q[VLAN]
+tags, the above filter is ineffective because the offset used are moved with
+four bytes. To fix this, you can enabled the `with_vlans` option, which will
+generate a BPF filter looking like this: `"port 80 or port 3306 and (vlan or (port 80 or port 3306))"`.
+
+==== bpf_filter
+
+Packetbeat automatically generates a
+https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
+the traffic on the ports on which the known protocols are expected to be found.
+For example, if you have configured port 80 for HTTP and port 3306 for MySQL,
+Packetbeat will generate the following BPF filter: `"port 80 or port 3306"`.
+
+With this setting, you can overwrite the generated BPF filter. For example:
+
+[source,yaml]
+------------------------------------------------------------------------------
+interfaces:
+  device: eth0
+  bpf_filter: "net 192.168.238.0/0 and port 80 and port 3306"
+------------------------------------------------------------------------------
+
+Note that this setting disables the automatic generation of the BPF filter so if
+you use it, it is your responsibility to keep the BPF filters in sync with the
+ports defined in the protocols sections.
+
+
 [[configuration-protocols]]
 === Protocols
 

--- a/packetbeat.dev.yml
+++ b/packetbeat.dev.yml
@@ -31,7 +31,8 @@ agent:
 # Select the network interfaces to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 interfaces:
- device: lo0
+ device: en0
+ bpf_filter: "net 192.168.239.0/24 and port 80"
 
 filter:
   filters: ["nop"]

--- a/protos/tcp/tcp_test.go
+++ b/protos/tcp/tcp_test.go
@@ -114,3 +114,36 @@ func Test_configToPortsMap_negative(t *testing.T) {
 		assert.Contains(t, err.Error(), test.Err)
 	}
 }
+
+func Test_portsToBpfFilter(t *testing.T) {
+	type io struct {
+		Ports     []int
+		WithVlans bool
+		Output    string
+	}
+
+	tests := []io{
+		io{
+			Ports:  []int{2, 3, 4},
+			Output: "port 2 or port 3 or port 4",
+		},
+		io{
+			Ports:  []int{80, 8080},
+			Output: "port 80 or port 8080",
+		},
+		io{
+			Ports:     []int{2, 3, 4},
+			WithVlans: true,
+			Output:    "port 2 or port 3 or port 4 or (vlan and (port 2 or port 3 or port 4))",
+		},
+		io{
+			Ports:     []int{80, 8080},
+			WithVlans: true,
+			Output:    "port 80 or port 8080 or (vlan and (port 80 or port 8080))",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.Output, portsToBpfFilter(test.Ports, test.WithVlans))
+	}
+}

--- a/sniffer/sniffer.go
+++ b/sniffer/sniffer.go
@@ -206,7 +206,10 @@ func (sniffer *SnifferSetup) Datalink() layers.LinkType {
 }
 
 func (sniffer *SnifferSetup) Init(test_mode bool, events chan common.MapStr) error {
-	config.ConfigSingleton.Interfaces.Bpf_filter = tcp.BpfFilter()
+	if config.ConfigSingleton.Interfaces.Bpf_filter == "" {
+		with_vlans := config.ConfigSingleton.Interfaces.With_vlans
+		config.ConfigSingleton.Interfaces.Bpf_filter = tcp.BpfFilter(with_vlans)
+	}
 
 	var err error
 	if !test_mode {


### PR DESCRIPTION
Generates BPF filters like this: "port 80 and (vlan and port 80)"
which is needed for capturing traffic that has 802.1Q tags.

This is done only optionally because, for example, if you try to
set this for the loopback interface on OS X, you will get an error.

Also adds the option to overwrite the BPF filter entirely from
the configuration file. This can be useful for excluding entire
hosts or networks from the packet capture at the lowest level.