### PR TITLE
Create basic test for Http::SetFromConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# IDE files / folders
+.idea


### PR DESCRIPTION
Here are some very basic tests for SetFromConfig which I wrote to get into the project.

I also added `.idea to` the `.gitignore` file to ignore the settings generated by IntellJ.