### PR TITLE
Specify interface numbers by index

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ type Config struct {
 
 type InterfacesConfig struct {
 	Device         string
-	Devices        []string
 	Type           string
 	File           string
 	With_vlans     bool

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -140,7 +140,7 @@ configuration:
 # Select the network interfaces to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 interfaces:
-  # On which devices to sniff
+  # On which device to sniff
   device: any
 
   # The maximum capture size of a single packet.
@@ -167,13 +167,24 @@ interfaces:
   device: eth0
 ------------------------------------------------------------------------------
 
-
-Alternatively, the Packetbeat shipper supports capturing of all messages sent or
-received by the server on which it is installed. For this, use the special
-"any" device.
+Alternatively, on Linux the Packetbeat shipper supports capturing of all
+messages sent or received by the server on which it is installed. For this, use
+the special "any" device.
 
 NOTE: When using the "any" device, the interfaces are not set
       in promiscuous mode.
+
+This option also accepts specifying the device by its index in the list of
+devices available for sniffing. To obtain the list of available devices, you can
+use run Packetbeat like this: `packetbeat -devices`. This is especially useful
+on Windows where device names are long. The following example will setup
+sniffing on the first interface available:
+
+[source,yaml]
+------------------------------------------------------------------------------
+interfaces:
+  device: 0
+------------------------------------------------------------------------------
 
 
 ===== snaplen

--- a/main.go
+++ b/main.go
@@ -61,7 +61,8 @@ func main() {
 	oneAtAtime := cmdLine.Bool("O", false, "Read packets one at a time (press Enter)")
 	topSpeed := cmdLine.Bool("t", false, "Read packets as fast as possible, without sleeping")
 	printVersion := cmdLine.Bool("version", false, "Print version and exit")
-	dumpfile := cmdLine.String("dump", "", "Write all captured packets to this libpcap file.")
+	dumpfile := cmdLine.String("dump", "", "Write all captured packets to this libpcap file")
+	printDevices := cmdLine.Bool("devices", false, "Print the list of devices and exit")
 
 	cmdLine.Parse(os.Args[1:])
 
@@ -70,6 +71,18 @@ func main() {
 	if *printVersion {
 		fmt.Printf("Packetbeat version %s (%s)\n", Version, runtime.GOARCH)
 		return
+	}
+
+	if *printDevices {
+		devs, err := sniffer.ListDeviceNames()
+		if err != nil {
+			fmt.Printf("Error getting devices list: %v\n", err)
+			os.Exit(1)
+		}
+		for i, dev := range devs {
+			fmt.Printf("%d: %s\n", i, dev)
+		}
+		os.Exit(0)
 	}
 
 	err := cfgfile.Read(&config.ConfigSingleton)

--- a/packetbeat.dev.yml
+++ b/packetbeat.dev.yml
@@ -32,7 +32,6 @@ agent:
 # keyword to sniff on all connected interfaces.
 interfaces:
  device: en0
- bpf_filter: "net 192.168.239.0/24 and port 80"
 
 filter:
   filters: ["nop"]

--- a/sniffer/sniffer.go
+++ b/sniffer/sniffer.go
@@ -73,13 +73,6 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 		sniffer.config.Device = "any"
 	}
 
-	if len(sniffer.config.Devices) == 0 {
-		// 'devices' not set but 'device' is set. For backwards compatibility,
-		// use the one configured device
-		if len(sniffer.config.Device) > 0 {
-			sniffer.config.Devices = []string{sniffer.config.Device}
-		}
-	}
 	if sniffer.config.Snaplen == 0 {
 		sniffer.config.Snaplen = 65535
 	}
@@ -88,7 +81,7 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 		sniffer.config.Type = "pcap"
 	}
 
-	logp.Debug("sniffer", "Sniffer type: %s devices: %s", sniffer.config.Type, sniffer.config.Devices)
+	logp.Debug("sniffer", "Sniffer type: %s device: %s", sniffer.config.Type, sniffer.config.Device)
 
 	switch sniffer.config.Type {
 	case "pcap":
@@ -98,11 +91,8 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 				return err
 			}
 		} else {
-			if len(sniffer.config.Devices) > 1 {
-				return fmt.Errorf("Pcap sniffer only supports one device. You can use 'any' if you want")
-			}
 			sniffer.pcapHandle, err = pcap.OpenLive(
-				sniffer.config.Devices[0],
+				sniffer.config.Device,
 				int32(sniffer.config.Snaplen),
 				true,
 				500*time.Millisecond)
@@ -122,10 +112,6 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 			sniffer.config.Buffer_size_mb = 24
 		}
 
-		if len(sniffer.config.Devices) > 1 {
-			return fmt.Errorf("Afpacket sniffer only supports one device. You can use 'any' if you want")
-		}
-
 		frame_size, block_size, num_blocks, err := afpacketComputeSize(
 			sniffer.config.Buffer_size_mb,
 			sniffer.config.Snaplen,
@@ -135,7 +121,7 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 		}
 
 		sniffer.afpacketHandle, err = NewAfpacketHandle(
-			sniffer.config.Devices[0],
+			sniffer.config.Device,
 			frame_size,
 			block_size,
 			num_blocks,
@@ -151,12 +137,8 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 
 		sniffer.DataSource = gopacket.PacketDataSource(sniffer.afpacketHandle)
 	case "pfring":
-		if len(sniffer.config.Devices) > 1 {
-			return fmt.Errorf("Afpacket sniffer only supports one device. You can use 'any' if you want")
-		}
-
 		sniffer.pfringHandle, err = NewPfringHandle(
-			sniffer.config.Devices[0],
+			sniffer.config.Device,
 			sniffer.config.Snaplen,
 			true)
 

--- a/sniffer/sniffer_test.go
+++ b/sniffer/sniffer_test.go
@@ -2,6 +2,8 @@ package sniffer
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSniffer_afpacketComputeSize(t *testing.T) {
@@ -48,4 +50,23 @@ func TestSniffer_afpacketComputeSize(t *testing.T) {
 	if frame_size != 4096*5 || block_size != 4096*5*128 || num_blocks != 1 {
 		t.Error("Bad result", frame_size, block_size, num_blocks)
 	}
+}
+
+func Test_deviceNameFromIndex(t *testing.T) {
+	devs := []string{"lo", "eth0", "eth1"}
+
+	name, err := deviceNameFromIndex(0, devs)
+	assert.Equal(t, "lo", name)
+	assert.NoError(t, err)
+
+	name, err = deviceNameFromIndex(1, devs)
+	assert.Equal(t, "eth0", name)
+	assert.NoError(t, err)
+
+	name, err = deviceNameFromIndex(2, devs)
+	assert.Equal(t, "eth1", name)
+	assert.NoError(t, err)
+
+	_, err = deviceNameFromIndex(3, devs)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
The goal is to make using Packetbeat easier on Windows. There the network interfaces have funky names like this one `\Device\NPF_{31C1C5B7-C0D6-4926-9331-95F9DB5CAD8E}`. We've previously asked Windows users to:

1. Download Windump, run `Windump -D` to print the device names
2. Copy and paste that long string in the configuration file
3. Escape the damn backslashes

This adds a CLI flag to print the devices to screen (thus removing the need for `Windump -D`) and makes the configuration accept the interface index instead of the full name. This also means we can have an works-out-of-the-box configuration file in the windows package.

This pull request also removes the `devices` configuration option, which was never documented and never actually made use of, because we support sniffing from a single device for now.