### PR TITLE
Restructuring of packetbeat

### DIFF
--- a/Godeps/_workspace/src/labix.org/v2/mgo/bson/bson.go
+++ b/Godeps/_workspace/src/labix.org/v2/mgo/bson/bson.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -425,7 +425,7 @@ func handleErr(err *error) {
 //         E int64  ",minsize"
 //         F int64  "myf,omitempty,minsize"
 //     }
-//           
+//
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := &encoder{make([]byte, 0, initialBufferSize)}

--- a/Godeps/_workspace/src/labix.org/v2/mgo/bson/bson_test.go
+++ b/Godeps/_workspace/src/labix.org/v2/mgo/bson/bson_test.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,8 +31,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
-	. "launchpad.net/gocheck"
 	"labix.org/v2/mgo/bson"
+	. "launchpad.net/gocheck"
 	"net/url"
 	"reflect"
 	"testing"
@@ -360,7 +360,7 @@ func (s *S) Test64bitInt(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(string(data), Equals, wrapInDoc("\x12i\x00\x00\x00\x00\x80\x00\x00\x00\x00"))
 
-		var result struct { I int }
+		var result struct{ I int }
 		err = bson.Unmarshal(data, &result)
 		c.Assert(err, IsNil)
 		c.Assert(int64(result.I), Equals, i)
@@ -832,7 +832,6 @@ func (s *S) TestUnmarshalSetterSetZero(c *C) {
 	c.Assert(value, IsNil)
 }
 
-
 // --------------------------------------------------------------------------
 // Getter test cases.
 
@@ -1245,7 +1244,10 @@ func (s *S) TestObjectIdHex(c *C) {
 }
 
 func (s *S) TestIsObjectIdHex(c *C) {
-	test := []struct{ id string; valid bool }{
+	test := []struct {
+		id    string
+		valid bool
+	}{
 		{"4d88e15b60f486e428412dc9", true},
 		{"4d88e15b60f486e428412dc", false},
 		{"4d88e15b60f486e428412dc9e", false},

--- a/Godeps/_workspace/src/labix.org/v2/mgo/bson/decode.go
+++ b/Godeps/_workspace/src/labix.org/v2/mgo/bson/decode.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/Godeps/_workspace/src/labix.org/v2/mgo/bson/encode.go
+++ b/Godeps/_workspace/src/labix.org/v2/mgo/bson/encode.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -364,7 +364,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		case time.Time:
 			// MongoDB handles timestamps as milliseconds.
 			e.addElemName('\x09', name)
-			e.addInt64(s.Unix() * 1000 + int64(s.Nanosecond() / 1e6))
+			e.addInt64(s.Unix()*1000 + int64(s.Nanosecond()/1e6))
 
 		case url.URL:
 			e.addElemName('\x02', name)

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -1,0 +1,122 @@
+package beat
+
+import (
+	"flag"
+	"fmt"
+	"github.com/elastic/libbeat/cfgfile"
+	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/outputs"
+	"github.com/elastic/libbeat/publisher"
+	"github.com/elastic/libbeat/service"
+	"os"
+	"runtime"
+)
+
+// Beater interface that every beat must use
+type Beater interface {
+	Config(*Beat) error
+	Setup(*Beat) error
+	Run(*Beat) error
+	Cleanup(*Beat) error
+	Stop()
+}
+
+// Basic beat information
+type Beat struct {
+	Name    string
+	Version string
+	CmdLine *flag.FlagSet
+	Config  BeatConfig
+	BT      Beater
+}
+
+// Basic configuration of every beat
+type BeatConfig struct {
+	Output  map[string]outputs.MothershipConfig
+	Logging logp.Logging
+	Shipper publisher.ShipperConfig
+}
+
+// Initiates a new beat object
+func NewBeat(name string, version string, bt Beater) *Beat {
+	b := Beat{
+		Version: version,
+		Name:    name,
+		BT:      bt,
+	}
+
+	b.CmdLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	return &b
+}
+
+// Reads and parses the default command line params
+// To set additional cmd line args use the beat.CmdLine type before calling the function
+func (beat *Beat) CommandLineSetup() {
+
+	cfgfile.CmdLineFlags(beat.CmdLine, beat.Name)
+	logp.CmdLineFlags(beat.CmdLine)
+	service.CmdLineFlags(beat.CmdLine)
+	publisher.CmdLineFlags(beat.CmdLine)
+
+	printVersion := beat.CmdLine.Bool("version", false, "Print version and exit")
+
+	beat.CmdLine.Parse(os.Args[1:])
+
+	if *printVersion {
+		fmt.Printf("%s version %s (%s)\n", beat.Name, beat.Version, runtime.GOARCH)
+		return
+	}
+}
+
+// Inits the config file and reads the default config information into Beat.Config
+// This is Output, Logging and Shipper config params
+func (b *Beat) LoadConfig() {
+
+	err := cfgfile.Read(&b.Config)
+
+	if err != nil {
+		logp.Debug("Log read error", "Error %v\n", err)
+	}
+
+	logp.Init(b.Name, &b.Config.Logging)
+
+	logp.Debug("main", "Initializing output plugins")
+
+	if err := publisher.Publisher.Init(b.Name, b.Config.Output, b.Config.Shipper); err != nil {
+		logp.Critical(err.Error())
+		os.Exit(1)
+	}
+
+	logp.Debug(b.Name, "Init %s", b.Name)
+}
+
+// internal libbeat function that calls beater Run method
+func (b *Beat) Run() {
+
+	// Setup beater object
+	b.BT.Setup(b)
+
+	// Up to here was the initialization, now about running
+	if cfgfile.IsTestConfig() {
+		// all good, exit with 0
+		os.Exit(0)
+	}
+	service.BeforeRun()
+
+	// Run beater specific stuff
+	b.BT.Run(b)
+
+	// Function called in case of beater stop
+	service.HandleSignals(b.BT.Stop)
+	service.Cleanup()
+
+	logp.Debug("main", "Cleanup")
+
+	// Call beater cleanup function
+	b.BT.Cleanup(b)
+}
+
+// Stops the beat and calls the beater Stop action
+func (beat *Beat) Stop() {
+	beat.BT.Stop()
+}

--- a/main.go
+++ b/main.go
@@ -1,211 +1,28 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	"runtime"
-	"time"
-
-	"github.com/elastic/libbeat/cfgfile"
-	"github.com/elastic/libbeat/common/droppriv"
-	"github.com/elastic/libbeat/filters"
-	"github.com/elastic/libbeat/filters/nop"
-	"github.com/elastic/libbeat/logp"
-	"github.com/elastic/libbeat/publisher"
-	"github.com/elastic/libbeat/service"
-
-	"github.com/elastic/packetbeat/config"
-	"github.com/elastic/packetbeat/procs"
-	"github.com/elastic/packetbeat/protos"
-	"github.com/elastic/packetbeat/protos/dns"
-	"github.com/elastic/packetbeat/protos/http"
-	"github.com/elastic/packetbeat/protos/mongodb"
-	"github.com/elastic/packetbeat/protos/mysql"
-	"github.com/elastic/packetbeat/protos/pgsql"
-	"github.com/elastic/packetbeat/protos/redis"
-	"github.com/elastic/packetbeat/protos/tcp"
-	"github.com/elastic/packetbeat/protos/thrift"
-	"github.com/elastic/packetbeat/protos/udp"
-	"github.com/elastic/packetbeat/sniffer"
+	"github.com/elastic/packetbeat/beat"
 )
-
-// You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
-var Version = "1.0.0-beta2"
-var Name = "packetbeat"
-
-var EnabledProtocolPlugins map[protos.Protocol]protos.ProtocolPlugin = map[protos.Protocol]protos.ProtocolPlugin{
-	protos.HttpProtocol:    new(http.Http),
-	protos.MysqlProtocol:   new(mysql.Mysql),
-	protos.PgsqlProtocol:   new(pgsql.Pgsql),
-	protos.RedisProtocol:   new(redis.Redis),
-	protos.ThriftProtocol:  new(thrift.Thrift),
-	protos.MongodbProtocol: new(mongodb.Mongodb),
-	protos.DnsProtocol:     new(dns.Dns),
-}
-
-var EnabledFilterPlugins map[filters.Filter]filters.FilterPlugin = map[filters.Filter]filters.FilterPlugin{
-	filters.NopFilter: new(nop.Nop),
-}
 
 func main() {
 
-	// Use our own FlagSet, because some libraries pollute the global one
-	var cmdLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	// Create Beater object
+	pb := &PacketBeat{}
 
-	cfgfile.CmdLineFlags(cmdLine, Name)
-	logp.CmdLineFlags(cmdLine)
-	service.CmdLineFlags(cmdLine)
-	publisher.CmdLineFlags(cmdLine)
+	// Initi beat objectefile
+	b := beat.NewBeat(Name, Version, pb)
 
-	file := cmdLine.String("I", "", "file")
-	loop := cmdLine.Int("l", 1, "Loop file. 0 - loop forever")
-	oneAtAtime := cmdLine.Bool("O", false, "Read packets one at a time (press Enter)")
-	topSpeed := cmdLine.Bool("t", false, "Read packets as fast as possible, without sleeping")
-	printVersion := cmdLine.Bool("version", false, "Print version and exit")
-	dumpfile := cmdLine.String("dump", "", "Write all captured packets to this libpcap file")
-	printDevices := cmdLine.Bool("devices", false, "Print the list of devices and exit")
+	// Additional command line args are used to overwrite config options
+	pb.CmdLineArgs = fetchAdditionalCmdLineArgs(b.CmdLine)
+	b.CommandLineSetup()
 
-	cmdLine.Parse(os.Args[1:])
+	// Loads base config
+	b.LoadConfig()
 
-	sniff := new(sniffer.SnifferSetup)
+	// Configures beat
+	pb.Config(b)
 
-	if *printVersion {
-		fmt.Printf("Packetbeat version %s (%s)\n", Version, runtime.GOARCH)
-		return
-	}
-
-	if *printDevices {
-		devs, err := sniffer.ListDeviceNames()
-		if err != nil {
-			fmt.Printf("Error getting devices list: %v\n", err)
-			os.Exit(1)
-		}
-		for i, dev := range devs {
-			fmt.Printf("%d: %s\n", i, dev)
-		}
-		os.Exit(0)
-	}
-
-	err := cfgfile.Read(&config.ConfigSingleton)
-
-	logp.Init(Name, &config.ConfigSingleton.Logging)
-
-	// CLI flags over-riding config
-	if *topSpeed {
-		config.ConfigSingleton.Interfaces.TopSpeed = true
-	}
-	if len(*file) > 0 {
-		config.ConfigSingleton.Interfaces.File = *file
-	}
-	config.ConfigSingleton.Interfaces.Loop = *loop
-	config.ConfigSingleton.Interfaces.OneAtATime = *oneAtAtime
-	if len(*dumpfile) > 0 {
-		config.ConfigSingleton.Interfaces.Dumpfile = *dumpfile
-	}
-
-	logp.Debug("main", "Initializing output plugins")
-	if err = publisher.Publisher.Init(Name, config.ConfigSingleton.Output, config.ConfigSingleton.Shipper); err != nil {
-
-		logp.Critical(err.Error())
-		os.Exit(1)
-	}
-
-	if err = procs.ProcWatcher.Init(config.ConfigSingleton.Procs); err != nil {
-		logp.Critical(err.Error())
-		os.Exit(1)
-	}
-
-	logp.Debug("main", "Initializing protocol plugins")
-	for proto, plugin := range EnabledProtocolPlugins {
-		err = plugin.Init(false, publisher.Publisher.Queue)
-		if err != nil {
-			logp.Critical("Initializing plugin %s failed: %v", proto, err)
-			os.Exit(1)
-		}
-		protos.Protos.Register(proto, plugin)
-	}
-
-	tcpProc, err := tcp.NewTcp(&protos.Protos)
-	if err != nil {
-		logp.Critical(err.Error())
-		os.Exit(1)
-	}
-	udpProc, err := udp.NewUdp(&protos.Protos)
-	if err != nil {
-		logp.Critical(err.Error())
-		os.Exit(1)
-	}
-
-	over := make(chan bool)
-
-	stopCb := func() {
-		sniff.Stop()
-	}
-
-	logp.Debug("main", "Initializing filters")
-	afterInputsQueue, err := filters.FiltersRun(
-		config.ConfigSingleton.Filter,
-		EnabledFilterPlugins,
-		publisher.Publisher.Queue,
-		stopCb)
-	if err != nil {
-		logp.Critical("%v", err)
-		os.Exit(1)
-	}
-
-	logp.Debug("main", "Initializing sniffer")
-	err = sniff.Init(false, afterInputsQueue, tcpProc, udpProc)
-	if err != nil {
-		logp.Critical("Initializing sniffer failed: %v", err)
-		os.Exit(1)
-	}
-
-	// This needs to be after the sniffer Init but before the sniffer Run.
-	if err = droppriv.DropPrivileges(config.ConfigSingleton.RunOptions); err != nil {
-		logp.Critical(err.Error())
-		os.Exit(1)
-	}
-
-	// Up to here was the initialization, now about running
-
-	if cfgfile.IsTestConfig() {
-		// all good, exit with 0
-		os.Exit(0)
-	}
-	service.BeforeRun()
-
-	// run the sniffer in background
-	go func() {
-		err := sniff.Run()
-		if err != nil {
-			logp.Critical("Sniffer main loop failed: %v", err)
-			os.Exit(1)
-		}
-		over <- true
-	}()
-
-	service.HandleSignals(stopCb)
-
-	// Startup successful, disable stderr logging if requested by
-	// cmdline flag
-	logp.SetStderr()
-
-	logp.Debug("main", "Waiting for the sniffer to finish")
-
-	// Wait for the goroutines to finish
-	for _ = range over {
-		if !sniff.IsAlive() {
-			break
-		}
-	}
-
-	logp.Debug("main", "Cleanup")
-
-	if service.WithMemProfile() {
-		// wait for all TCP streams to expire
-		time.Sleep(tcp.TCP_STREAM_EXPIRY * 1.2)
-		tcpProc.PrintTcpMap()
-	}
-	service.Cleanup()
+	// Run beat. This calls first beater.Setup,
+	// then beater.Run and beater.Cleanup in the end
+	b.Run()
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 func main() {
 
 	// Create Beater object
-	pb := &PacketBeat{}
+	pb := &Packetbeat{}
 
 	// Initi beat objectefile
 	b := beat.NewBeat(Name, Version, pb)

--- a/packetbeat.go
+++ b/packetbeat.go
@@ -47,7 +47,7 @@ var EnabledFilterPlugins map[filters.Filter]filters.FilterPlugin = map[filters.F
 }
 
 // Beater object. Contains all objects needed to run the beat
-type PacketBeat struct {
+type Packetbeat struct {
 	PbConfig    config.Config
 	CmdLineArgs CmdLineArgs
 	Sniff       *sniffer.SnifferSetup
@@ -79,7 +79,7 @@ func fetchAdditionalCmdLineArgs(cmdLine *flag.FlagSet) CmdLineArgs {
 }
 
 // Loads the beat specific config and overwrites params based on cmd line
-func (pb *PacketBeat) Config(b *beat.Beat) error {
+func (pb *Packetbeat) Config(b *beat.Beat) error {
 	// Read beat implementation config as needed for setup
 	err := cfgfile.Read(&pb.PbConfig)
 
@@ -119,7 +119,7 @@ func (pb *PacketBeat) Config(b *beat.Beat) error {
 }
 
 // Setup packetbeat
-func (pb *PacketBeat) Setup(b *beat.Beat) error {
+func (pb *Packetbeat) Setup(b *beat.Beat) error {
 
 	if err := procs.ProcWatcher.Init(pb.PbConfig.Procs); err != nil {
 		logp.Critical(err.Error())
@@ -181,7 +181,7 @@ func (pb *PacketBeat) Setup(b *beat.Beat) error {
 	return err
 }
 
-func (pb *PacketBeat) Run(b *beat.Beat) error {
+func (pb *Packetbeat) Run(b *beat.Beat) error {
 
 	// run the sniffer in background
 	go func() {
@@ -209,7 +209,7 @@ func (pb *PacketBeat) Run(b *beat.Beat) error {
 	return nil
 }
 
-func (pb *PacketBeat) Cleanup(b *beat.Beat) error {
+func (pb *Packetbeat) Cleanup(b *beat.Beat) error {
 
 	if service.WithMemProfile() {
 		// wait for all TCP streams to expire
@@ -220,6 +220,6 @@ func (pb *PacketBeat) Cleanup(b *beat.Beat) error {
 }
 
 // Called by the Beat stop function
-func (pb *PacketBeat) Stop() {
+func (pb *Packetbeat) Stop() {
 	pb.Sniff.Stop()
 }

--- a/packetbeat.go
+++ b/packetbeat.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/elastic/libbeat/cfgfile"
+	"github.com/elastic/libbeat/common/droppriv"
+	"github.com/elastic/libbeat/filters"
+	"github.com/elastic/libbeat/filters/nop"
+	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/publisher"
+	"github.com/elastic/libbeat/service"
+	"github.com/elastic/packetbeat/beat"
+	"github.com/elastic/packetbeat/config"
+	"github.com/elastic/packetbeat/procs"
+	"github.com/elastic/packetbeat/protos"
+	"github.com/elastic/packetbeat/protos/dns"
+	"github.com/elastic/packetbeat/protos/http"
+	"github.com/elastic/packetbeat/protos/mongodb"
+	"github.com/elastic/packetbeat/protos/mysql"
+	"github.com/elastic/packetbeat/protos/pgsql"
+	"github.com/elastic/packetbeat/protos/redis"
+	"github.com/elastic/packetbeat/protos/tcp"
+	"github.com/elastic/packetbeat/protos/thrift"
+	"github.com/elastic/packetbeat/protos/udp"
+	"github.com/elastic/packetbeat/sniffer"
+	"os"
+	"time"
+)
+
+// You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
+var Version = "1.0.0-beta2"
+var Name = "packetbeat"
+
+var EnabledProtocolPlugins map[protos.Protocol]protos.ProtocolPlugin = map[protos.Protocol]protos.ProtocolPlugin{
+	protos.HttpProtocol:    new(http.Http),
+	protos.MysqlProtocol:   new(mysql.Mysql),
+	protos.PgsqlProtocol:   new(pgsql.Pgsql),
+	protos.RedisProtocol:   new(redis.Redis),
+	protos.ThriftProtocol:  new(thrift.Thrift),
+	protos.MongodbProtocol: new(mongodb.Mongodb),
+	protos.DnsProtocol:     new(dns.Dns),
+}
+
+var EnabledFilterPlugins map[filters.Filter]filters.FilterPlugin = map[filters.Filter]filters.FilterPlugin{
+	filters.NopFilter: new(nop.Nop),
+}
+
+// Beater object. Contains all objects needed to run the beat
+type PacketBeat struct {
+	PbConfig    config.Config
+	CmdLineArgs CmdLineArgs
+	Sniff       *sniffer.SnifferSetup
+	over        chan bool
+	tcpProc     *tcp.Tcp
+}
+
+type CmdLineArgs struct {
+	File         *string
+	Loop         *int
+	OneAtAtime   *bool
+	TopSpeed     *bool
+	Dumpfile     *string
+	PrintDevices *bool
+}
+
+func fetchAdditionalCmdLineArgs(cmdLine *flag.FlagSet) CmdLineArgs {
+
+	args := CmdLineArgs{
+		File:         cmdLine.String("I", "", "file"),
+		Loop:         cmdLine.Int("l", 1, "Loop file. 0 - loop forever"),
+		OneAtAtime:   cmdLine.Bool("O", false, "Read packets one at a time (press Enter)"),
+		TopSpeed:     cmdLine.Bool("t", false, "Read packets as fast as possible, without sleeping"),
+		Dumpfile:     cmdLine.String("dump", "", "Write all captured packets to this libpcap file"),
+		PrintDevices: cmdLine.Bool("devices", false, "Print the list of devices and exit"),
+	}
+
+	return args
+}
+
+// Loads the beat specific config and overwrites params based on cmd line
+func (pb *PacketBeat) Config(b *beat.Beat) error {
+	// Read beat implementation config as needed for setup
+	err := cfgfile.Read(&pb.PbConfig)
+
+	// CLI flags over-riding config
+	if *pb.CmdLineArgs.TopSpeed {
+		pb.PbConfig.Interfaces.TopSpeed = true
+	}
+
+	if len(*pb.CmdLineArgs.File) > 0 {
+		pb.PbConfig.Interfaces.File = *pb.CmdLineArgs.File
+	}
+
+	pb.PbConfig.Interfaces.Loop = *pb.CmdLineArgs.Loop
+	pb.PbConfig.Interfaces.OneAtATime = *pb.CmdLineArgs.OneAtAtime
+
+	if len(*pb.CmdLineArgs.Dumpfile) > 0 {
+		pb.PbConfig.Interfaces.Dumpfile = *pb.CmdLineArgs.Dumpfile
+	}
+
+	if *pb.CmdLineArgs.PrintDevices {
+		devs, err := sniffer.ListDeviceNames()
+		if err != nil {
+			fmt.Printf("Error getting devices list: %v\n", err)
+			os.Exit(1)
+		}
+		for i, dev := range devs {
+			fmt.Printf("%d: %s\n", i, dev)
+		}
+		os.Exit(0)
+	}
+
+	// assign global singleton as it is used in protocols
+	// TODO: Refactor
+	config.ConfigSingleton = pb.PbConfig
+
+	return err
+}
+
+// Setup packetbeat
+func (pb *PacketBeat) Setup(b *beat.Beat) error {
+
+	if err := procs.ProcWatcher.Init(pb.PbConfig.Procs); err != nil {
+		logp.Critical(err.Error())
+		os.Exit(1)
+	}
+
+	pb.Sniff = new(sniffer.SnifferSetup)
+
+	logp.Debug("main", "Initializing protocol plugins")
+	for proto, plugin := range EnabledProtocolPlugins {
+		err := plugin.Init(false, publisher.Publisher.Queue)
+		if err != nil {
+			logp.Critical("Initializing plugin %s failed: %v", proto, err)
+			os.Exit(1)
+		}
+		protos.Protos.Register(proto, plugin)
+	}
+
+	var err error
+
+	pb.tcpProc, err = tcp.NewTcp(&protos.Protos)
+	if err != nil {
+		logp.Critical(err.Error())
+		os.Exit(1)
+	}
+	udpProc, err := udp.NewUdp(&protos.Protos)
+	if err != nil {
+		logp.Critical(err.Error())
+		os.Exit(1)
+	}
+
+	pb.over = make(chan bool)
+
+	logp.Debug("main", "Initializing filters")
+	afterInputsQueue, err := filters.FiltersRun(
+		config.ConfigSingleton.Filter,
+		EnabledFilterPlugins,
+		publisher.Publisher.Queue,
+		b.Stop)
+
+	if err != nil {
+		logp.Critical("%v", err)
+		os.Exit(1)
+	}
+
+	logp.Debug("main", "Initializing sniffer")
+	err = pb.Sniff.Init(false, afterInputsQueue, pb.tcpProc, udpProc)
+	if err != nil {
+		logp.Critical("Initializing sniffer failed: %v", err)
+		os.Exit(1)
+	}
+
+	// This needs to be after the sniffer Init but before the sniffer Run.
+	if err = droppriv.DropPrivileges(config.ConfigSingleton.RunOptions); err != nil {
+		logp.Critical(err.Error())
+		os.Exit(1)
+	}
+
+	return err
+}
+
+func (pb *PacketBeat) Run(b *beat.Beat) error {
+
+	// run the sniffer in background
+	go func() {
+		err := pb.Sniff.Run()
+		if err != nil {
+			logp.Critical("Sniffer main loop failed: %v", err)
+			os.Exit(1)
+		}
+		pb.over <- true
+	}()
+
+	// Startup successful, disable stderr logging if requested by
+	// cmdline flag
+	logp.SetStderr()
+
+	logp.Debug("main", "Waiting for the sniffer to finish")
+
+	// Wait for the goroutines to finish
+	for _ = range pb.over {
+		if !pb.Sniff.IsAlive() {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (pb *PacketBeat) Cleanup(b *beat.Beat) error {
+
+	if service.WithMemProfile() {
+		// wait for all TCP streams to expire
+		time.Sleep(tcp.TCP_STREAM_EXPIRY * 1.2)
+		pb.tcpProc.PrintTcpMap()
+	}
+	return nil
+}
+
+// Called by the Beat stop function
+func (pb *PacketBeat) Stop() {
+	pb.Sniff.Stop()
+}

--- a/tests/templates/packetbeat.yml.j2
+++ b/tests/templates/packetbeat.yml.j2
@@ -196,7 +196,7 @@ output:
 
 {% if procs_enabled %}
 # Configure the processes to be monitored and how to find them. If a process is
-# monitored than PacketBeat attempts to use it's name to fill in the `proc` and
+# monitored than Packetbeat attempts to use it's name to fill in the `proc` and
 # `client_proc` fields.
 # The processes can be found by searching their command line by a given string.
 #


### PR DESCRIPTION
Packetbeat was restructure so common parts of every beat could be moved to libbeat. All common functionality is in beat.go. Every beat should extend Beater and use the beat object. Every Beater has the following functions:
* Config
* Setup
* Run
* Cleanup
* Stop

The function Setup, Run and Cleanup are directly run by the Beat Run function. 

Beater and Beat have its own Config object. This allows beat to have the standard configuration which is needed for libbeat and the specific beater config implementation is read separately.

The main goal is to make the creation of new beats as easy as possible and that improvements made to the base technology automatically apply to all existing beats when updated.