### PR TITLE
Brought back parallel execution of integration tests.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-PROCESSES ?= 1
+PROCESSES ?= 4
+TIMEOUT ?= 30
 
 env: env/bin/activate
 env/bin/activate: requirements.txt
@@ -10,4 +11,4 @@ env/bin/activate: requirements.txt
 .PHONY: test
 test: env
 	make -C ..
-	. env/bin/activate; nosetests --processes=${PROCESSES}
+	. env/bin/activate; nosetests --processes=${PROCESSES} --process-timeout=$(TIMEOUT)


### PR DESCRIPTION
I think the issue was with nose multiprocessing module and the seemingly arbitrary limit of 10 seconds for each process.

I ran `env PROCESSES=6 make test` in a loop on my computer and it didn't fail in a dozen or so iterations.