### PR TITLE
Adding device descriptions to the -device output.

### DIFF
--- a/docs/windows.asciidoc
+++ b/docs/windows.asciidoc
@@ -24,7 +24,7 @@ Use the following command to list the available network interfaces:
 ----------------------------------------------------------------------
 PS > .\packetbeat.exe -devices
 
-0: \Device\NPF_{113535AD-934A-452E-8D5F-3004797DE286}
+0: \Device\NPF_{113535AD-934A-452E-8D5F-3004797DE286} (Intel(R) PRO/1000 MT Desktop Adapter)
 ----------------------------------------------------------------------
 
 In this example, there is only one network card installed on the system. If

--- a/sniffer/sniffer.go
+++ b/sniffer/sniffer.go
@@ -75,7 +75,11 @@ func ListDeviceNames() ([]string, error) {
 
 	ret := []string{}
 	for _, dev := range devices {
-		ret = append(ret, dev.Name)
+		desc := "No description available"
+		if len(dev.Description) > 0 {
+			desc = dev.Description
+		}
+		ret = append(ret, fmt.Sprintf("%s (%s)", dev.Name, desc))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
The description helps associate the index and name with a particular NIC on Windows.

The output is similar to https://www.winpcap.org/docs/docs_40_2/html/group__wpcap__tut1.html

One possible change to this pull request would be to not print `(No description available)` when `dev.Description` is empty.