### PR TITLE
fix getting dependencies via getdeps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ with_pfring:
 
 .PHONY: getdeps
 getdeps:
-	go get -t -u -f
+	go get -t -u -f ./...
 	# goautotest is used from the Makefile to run tests in a loop
 	go get -u github.com/tsg/goautotest
 	# websocket is needed by the gobeacon tests


### PR DESCRIPTION
* not specifying ./... only the package ("main") in the current directory
  is used (see "go help packages") to resolve dependencies
* so dependencies from all other packages incl. tests have been missing
* this is especially obvious when running "make updatedeps"
  on a fresh/empty $GOPATH; it cannot find packages in $GOPATH that are
  contained in Godeps