### PR TITLE
Remove the go-daemon submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go-daemon"]
-	path = go-daemon
-	url = https://github.com/fiorix/go-daemon.git


### PR DESCRIPTION
Go-daemon is still used but it's added by the beats-packer at
packaging time, so we no longer need it here as a git submodule.

Also cleanup the Makefile, a few targets are no longer needed
because packaging is now handled by the beats-packer.