### PR TITLE
Print "No devices found" when -devices is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,7 @@ All notable changes to this project will be documented in this file based on the
 - Generate coverage for system tests
 - Move go-daemon dependency to beats-packer
 - Rename integration tests to system tests
+- Made the `-devices` option more user friendly in case `sudo` is not used.
+  Issue #296.
 
 ### Deprecated

--- a/packetbeat.go
+++ b/packetbeat.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/elastic/libbeat/beat"
@@ -94,6 +95,14 @@ func (pb *Packetbeat) CliFlags(b *beat.Beat) {
 		if err != nil {
 			fmt.Printf("Error getting devices list: %v\n", err)
 			os.Exit(1)
+		}
+		if len(devs) == 0 {
+			fmt.Printf("No devices found.")
+			if runtime.GOOS != "windows" {
+				fmt.Printf(" You might need sudo?\n")
+			} else {
+				fmt.Printf("\n")
+			}
 		}
 		for i, dev := range devs {
 			fmt.Printf("%d: %s\n", i, dev)


### PR DESCRIPTION
Also add a "use sudo" suggestion on darwin/linux. This makes it
less confusing when you forget to run packetbeat -devices as a non-root
user.

Closes #296.