### PR TITLE
Add a transaction "direction" field to fields.yml

### DIFF
--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -125,6 +125,15 @@ event:
         UIs to return estimated values.
       required: true
 
+    - name: direction
+      required: true
+      description: >
+        Indicates whether the transaction is inbound (emitted by server)
+        or outbound (emitted by the client). Values can be in or out. No defaults.
+      possible_values:
+        - in
+        - out
+
     - name: status
       description: >
         High level status of the transaction. The way to compute this


### PR DESCRIPTION
The direction field indicates whether an output emitted by a node is for an inbound transaction (at server) or outbound (at client). Refer to PR elastic/libbeat pull request num. 150