### PR TITLE
Fix #329

### DIFF
--- a/packetbeat.go
+++ b/packetbeat.go
@@ -91,7 +91,7 @@ func fetchAdditionalCmdLineArgs() CmdLineArgs {
 func (pb *Packetbeat) CliFlags(b *beat.Beat) {
 	// -devices CLI flag
 	if *pb.CmdLineArgs.PrintDevices {
-		devs, err := sniffer.ListDeviceNames()
+		devs, err := sniffer.ListDeviceNames(true)
 		if err != nil {
 			fmt.Printf("Error getting devices list: %v\n", err)
 			os.Exit(1)

--- a/sniffer/sniffer.go
+++ b/sniffer/sniffer.go
@@ -66,7 +66,10 @@ func deviceNameFromIndex(index int, devices []string) (string, error) {
 	return devices[index], nil
 }
 
-func ListDeviceNames() ([]string, error) {
+// ListDevicesNames returns the list of adapters available for sniffing on
+// this computer. If the withDescription parameter is set to true, a human
+// readable version of the adapter name is added.
+func ListDeviceNames(withDescription bool) ([]string, error) {
 	devices, err := pcap.FindAllDevs()
 	if err != nil {
 		return []string{}, err
@@ -74,11 +77,15 @@ func ListDeviceNames() ([]string, error) {
 
 	ret := []string{}
 	for _, dev := range devices {
-		desc := "No description available"
-		if len(dev.Description) > 0 {
-			desc = dev.Description
+		if withDescription {
+			desc := "No description available"
+			if len(dev.Description) > 0 {
+				desc = dev.Description
+			}
+			ret = append(ret, fmt.Sprintf("%s (%s)", dev.Name, desc))
+		} else {
+			ret = append(ret, dev.Name)
 		}
-		ret = append(ret, fmt.Sprintf("%s (%s)", dev.Name, desc))
 	}
 	return ret, nil
 }
@@ -100,7 +107,7 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 	}
 
 	if index, err := strconv.Atoi(sniffer.config.Device); err == nil { // Device is numeric
-		devices, err := ListDeviceNames()
+		devices, err := ListDeviceNames(false)
 		if err != nil {
 			return fmt.Errorf("Error getting devices list: %v", err)
 		}


### PR DESCRIPTION
Adds a parameter to request the description or not, so the
-devices prints the description but when resolving an index
number we don't get the description.