### PR TITLE
preserve packetbeat.yml during rpm update

### DIFF
--- a/rpm/packetbeat.spec
+++ b/rpm/packetbeat.spec
@@ -32,7 +32,7 @@ install -D rpm/packetbeat.init %{buildroot}/etc/rc.d/init.d/packetbeat
 /usr/bin/*
 /etc/rc.d/init.d/packetbeat
 /etc/packetbeat/packetbeat.template.json
-%config /etc/packetbeat/packetbeat.yml
+%config(noreplace) /etc/packetbeat/packetbeat.yml
 
 %doc debian/copyright
 


### PR DESCRIPTION
adding rpm spec `(noreplace)` to preserve file `/etc/packetbeat/packetbeat.yml` during rpm `update`.

Fixes #334 