### PR TITLE
Fix process monitoring FD leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Close file descriptors used to monitor processes. #337
 
 ### Added
 

--- a/procs/procs.go
+++ b/procs/procs.go
@@ -168,6 +168,7 @@ func FindPidsByCmdlineGrep(prefix string, process string) ([]int, error) {
 	if err != nil {
 		return pids, fmt.Errorf("Open /proc: %s", err)
 	}
+	defer proc.Close()
 
 	names, err := proc.Readdirnames(0)
 	if err != nil {
@@ -271,6 +272,7 @@ func (proc *ProcessesWatcher) UpdateMap() {
 		logp.Err("Open: %s", err)
 		return
 	}
+	defer file.Close()
 	socks, err := Parse_Proc_Net_Tcp(file)
 	if err != nil {
 		logp.Err("Parse_Proc_Net_Tcp: %s", err)
@@ -365,6 +367,7 @@ func FindSocketsOfPid(prefix string, pid int) (inodes []int64, err error) {
 	if err != nil {
 		return []int64{}, fmt.Errorf("Open: %s", err)
 	}
+	defer procfs.Close()
 	names, err := procfs.Readdirnames(0)
 	if err != nil {
 		return []int64{}, fmt.Errorf("Readdirnames: %s", err)


### PR DESCRIPTION
Fixes a file descriptor leak in the process monitoring feature. The golang garbage collector automatically closes the FD associated with os.File which is why the FD count didn't grow completely unbounded; in my testing the FD count would cyclically grow to about ~500 and then drop back down to ~5.

Close #335