### PR TITLE
implements terminology change to remove the word shippers 

### DIFF
--- a/docs/capturing.asciidoc
+++ b/docs/capturing.asciidoc
@@ -1,7 +1,7 @@
 [[capturing-options]]
-== Traffic capturing options
+== Traffic Capturing Options
 
-There are two main ways of deploying the Packetbeat shipper:
+There are two main ways of deploying Packetbeat:
 
 * On dedicated servers, getting the traffic from mirror ports or tap devices.
 
@@ -13,8 +13,8 @@ generally not available on cloud setups.
 
 In both cases, the sniffing (reading packets passively from the network)
 performance is very important. In the case of a dedicated server, better
-sniffing performance means less hardware required. In the shipper case, better
-sniffing performance means less overhead.
+sniffing performance means less hardware required. When Packetbeat is installed 
+on an existing application server, better sniffing performance means less overhead.
 
 Currently Packetbeat has several options for traffic capturing:
 
@@ -33,8 +33,8 @@ Gigabits per second using only standard hardware.
 The `af_packet` option, also known as "memory mapped sniffing" makes use of a
 Linux specific
 http://lxr.free-electrons.com/source/Documentation/networking/packet_mmap.txt[feature].
-This could be the optimal sniffing mode for both the dedicated server and the
-shipper cases.
+This could be the optimal sniffing mode for both the dedicated server and 
+when Packetbeat is deployed on an existing application server.
 
 The way it works is that both the kernel and the user space program map the
 same memory zone and a simple circular buffer is organized in this memory zone.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,11 +1,12 @@
 [[packetbeat-configuration]]
-== Configuration
+== Configuration Options
 
 The Packetbeat configuration file uses http://yaml.org/[YAML] as any other Beat. 
 It consists of the following sections:
 
 
-* {libbeat}/configuration.html#configuration-shipper[Shipper]
+* {libbeat}/configuration.html#configuration-shipper[Shipper] (this section is covered in the
+{libbeat}/configuration.html#configuration-shipper[Beats Platform Reference])
 * <<configuration-interfaces>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
@@ -53,7 +54,7 @@ interfaces:
   device: eth0
 ------------------------------------------------------------------------------
 
-Alternatively, on Linux the Packetbeat shipper supports capturing of all
+Alternatively, on Linux Packetbeat supports capturing of all
 messages sent or received by the server on which it is installed. For this, use
 the special "any" device.
 
@@ -110,7 +111,7 @@ interfaces:
   type: af_packet
 ------------------------------------------------------------------------------
 
-If you are on Linux and you are trying to optimize the CPU usage of the shipper,
+If you are on Linux and you are trying to optimize the CPU usage of Packetbeat,
 we recommend trying the `af_packet` and `pf_ring` options. Read this
 http://packetbeat.com/blog/sniffing-performance-and-ipv6.html[blog post]
 for some details.
@@ -133,7 +134,7 @@ interfaces:
   buffer_size_mb: 100
 ------------------------------------------------------------------------------
 
-==== with_vlans
+===== with_vlans
 
 Packetbeat automatically generates a
 https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
@@ -146,7 +147,7 @@ tags, the above filter is ineffective because the offset used are moved with
 four bytes. To fix this, you can enabled the `with_vlans` option, which will
 generate a BPF filter looking like this: `"port 80 or port 3306 or (vlan and (port 80 or port 3306))"`.
 
-==== bpf_filter
+===== bpf_filter
 
 Packetbeat automatically generates a
 https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
@@ -212,16 +213,16 @@ protocols:
     ports: [9090]
 ------------------------------------------------------------------------------
 
-==== Common protocol options
+==== Common Protocol Options
 
 The following options are available for all protocols:
 
 ===== ports
 
-The Packetbeat shipper installs a BPF filter based on the ports configured in
+Packetbeat installs a BPF filter based on the ports configured in
 this section.
 If a packet doesn't match the filter, very little CPU is required to discard
-the packet. The shipper also uses the ports configured here to decide which
+the packet. Packetbeat also uses the ports configured here to decide which
 parser to use for each packet.
 
 ===== send_request
@@ -243,7 +244,7 @@ by default, only the HTTP headers.
 Per protocol transaction timeout. Expired transaction won't be correlated to incoming responses anymore, but sent to Elasticsearch immediately.
 
 
-==== DNS configuration
+==== DNS Configuration
 
 DNS protocol supports processing DNS message on UDP. Here is a sample configuration section for DNS:
 
@@ -273,7 +274,7 @@ By default publishing authority data is disabled.
 If enabled dns.additionals field (additional resource records) are added to DNS events.
 By default publishing additional resource records is disabled.
 
-==== HTTP configuration
+==== HTTP Configuration
 
 The Http protocol has several specific configuration options. Here is a
 sample configuration section:
@@ -308,11 +309,11 @@ protocols:
 
 ===== hide_keywords
 
-The Packetbeat shipper has the option of automatically censor certain strings
+Packetbeat has the option of automatically censor certain strings
 from the transactions it saves. This is done because while the SQL traffic
 typically only contains the hashes of the passwords, it is possible that the
-HTTP traffic contains sensitive data. In order to reduce the security risks,
-the shipper can automatically avoid sending the contents of certain HTTP POST
+HTTP traffic contains sensitive data. In order to reduce the security risks, 
+Packetbeat can automatically avoid sending the contents of certain HTTP POST
 parameters. The sensitive content associated with these keywords is replaced
 by ``xxxxx``. By default, no changes are made to the HTTP messages.
 
@@ -398,7 +399,7 @@ information. If this header is present and contains a valid IP addresses, the
 information is used for the `real_ip` and `client_location` indexed
 fields.
 
-==== Memcache configuration
+==== Memcache Configuration
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -445,7 +446,7 @@ before publishing quiet messages. Non quiet messages or quiet requests with
 error response will not have to wait for the timeout.
 
 
-==== MySQL and PgSQL configuration
+==== MySQL and PgSQL Configuration
 
 ===== max_rows
 
@@ -459,7 +460,7 @@ Maximum length in bytes of a row from the SQL message to publish to
 Elasticsearch. The default is 1024 bytes.
 
 [[configuration-thrift]]
-==== Thrift configuration
+==== Thrift Configuration
 
 Thrift protocol has several specific configuration options. Here is a
 sample configuration section:
@@ -490,8 +491,8 @@ corresponding to the TBinary protocol, which is the default Thrift protocol.
 
 ===== idl_files
 
-The Thrift Interface description language (IDL) files for the service that the
-shipper is monitoring. Providing the IDL files is optional, because the Thrift
+The Thrift Interface description language (IDL) files for the service that 
+Packetbeat is monitoring. Providing the IDL files is optional, because the Thrift
 messages contain enough information to decode them without having the IDL
 files. However, providing the IDL will additionally fill in parameter and
 exceptions names.
@@ -510,7 +511,7 @@ added at the end to mark that the collection was truncated. The default is 15.
 
 ===== capture_reply
 
-If set to false, the Packetbeat shipper only decodes the method name from
+If set to false, Packetbeat only decodes the method name from
 the reply and simply skip the rest of the response message. This can be useful
 for performance, disk usage or data retention reasons. The default is true.
 
@@ -521,14 +522,14 @@ in the return code or in the exception structures with the `"*"` string.
 
 ===== drop_after_n_struct_fields
 
-If a structure has more fields than this given value, the Packetbeat shipper will
-ignore the whole transaction. This is a memory protection mechanism (so that
-the shipper's memory doesn't grow indefinitely), so you would topically set this
+If a structure has more fields than this given value, Packetbeat will
+ignore the whole transaction. This is a memory protection mechanism (so that 
+Packetbeat's memory doesn't grow indefinitely), so you would topically set this
 to a relatively high value. The default is 500.
 
 
 [[configuration-mongodb]]
-==== MongoDB configuration
+==== MongoDB Configuration
 
 The following settings are specific to the MongoDB protocol. Here is a sample
 configuration section:
@@ -555,7 +556,7 @@ more documents but they weren't saved because of this setting.
 
 ===== max_doc_length
 
-Maximum number of characters in a single document indexed in the `resposne`
+Maximum number of characters in a single document indexed in the `response`
 field. The default is 5000. You can set this to 0 to index an unlimited number
 of characters per document.
 
@@ -567,14 +568,14 @@ formatted JSON objects.
 
 
 [[maintaining-topology]]
-=== Maintaining the real-time state of the network topology
+=== Maintaining the Real-time State of the Network Topology
 
 One of the important features of Packetbeat is that it knows for each
 transaction which is the source server and is the destination server by names.
 It does this without the requirement of maintaining a central configuration.
-Instead each shipper notes the hostname of the server on which it runs on, and
+Instead each Beat notes the hostname of the server on which it runs, and
 maps that to the list of IP addresses of that server. This information is
-shared between shippers by using the mechanisms provided by the output plugins.
+shared between Beats by using the mechanisms provided by the output plugins.
 
 For example, the Redis output plugin stores the topology in a dedicated Redis
 database and the Elasticsearch output plugin stores the topology in an
@@ -590,25 +591,25 @@ controlled from the `save_topology` configuration option.
 [[configuration-processes]]
 === Processes (optional)
 
-This section is optional, but configuring the processes enables Packetbeat
-shipper to not only show you between which servers the traffic is flowing, but
+This section is optional, but configuring the processes enables Packetbeat 
+to not only show you between which servers the traffic is flowing, but
 also between which processes. It can even show you the traffic between two
 processes running on the same host, so this is particularly useful when you
 have more services running on the same server. By default, process matching
 is disabled.
 
-When it starts (and then periodically) the shipper scans the process table for
+When it starts (and then periodically) Packetbeat scans the process table for
 processes matching the configuration file. For each of these processes, it
 monitors which file descriptors it has opened. When a new packet is captured,
 it reads the list of active TCP connections and matches the corresponding one
 with the list of file descriptors.
 
 On a Linux system, all this information is available via the `/proc`
-filesystem, so the Packetbeat shipper doesn't need a kernel module.
+filesystem, so Packetbeat doesn't need a kernel module.
 
 
 NOTE: Process monitoring is currently only supported on
-      Linux systems. The Packetbeat shipper automatically disables
+      Linux systems. Packetbeat automatically disables
       it when it detects other operating systems.
 
 Example configuration:
@@ -643,7 +644,7 @@ app" instead of "gunicorn")
 ===== cmdline_grep
 
 This option for each process is used to identify the process at
-runtime. When it starts, and then periodically, the shipper scans the process table for
+runtime. When it starts, and then periodically, Packetbeat scans the process table for
 processes matching `cmdline_grep` option. The match is done against the
 process' command line as read from `/proc/<pid>/cmdline`.
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -4,10 +4,10 @@ This file is generated! See etc/fields.yml and scripts/generate_field_docs.py
 ////
 
 [[exported-fields]]
-== Exported fields
+== Exported Fields
 
-This document describes the fields that are exported by the
-Packetbeat shipper for each transaction. They are grouped in the
+This document describes the fields that are exported by 
+Packetbeat for each transaction. They are grouped in the
 following categories:
 
 * <<exported-fields-event>>
@@ -24,7 +24,7 @@ following categories:
 * <<exported-fields-raw>>
 
 [[exported-fields-event]]
-=== Event fields
+=== Event Fields
 
 These fields contained data about the transaction itself.
 
@@ -40,7 +40,7 @@ format: YYYY-MM-DDTHH:MM:SS.milliZ
 
 required: True
 
-The timestamp of the event, as measured either by the shipper or by a common collector point. The precision is in milliseconds. The timezone is UTC.
+The timestamp of the event, as measured either by the Beat or by a common collector point. The precision is in milliseconds. The timezone is UTC.
 
 
 ==== type
@@ -108,7 +108,7 @@ Messages from Packetbeat itself. This usually contains error messages for interp
 
 
 [[exported-fields-dns]]
-=== DNS fields
+=== DNS Fields
 
 DNS specific event fields.
 
@@ -313,7 +313,7 @@ The data describing the resource. The meaning of this data depends on the type a
 
 
 [[exported-fields-http]]
-=== Http fields
+=== Http Fields
 
 HTTP specific event fields.
 
@@ -352,7 +352,7 @@ The value of the Content-Length header if present.
 
 
 [[exported-fields-memcache]]
-=== Memcache fields
+=== Memcache Fields
 
 Memcached specific event fields
 
@@ -652,7 +652,7 @@ Returned memcache version string.
 
 
 [[exported-fields-mysql]]
-=== Mysql fields
+=== Mysql Fields
 
 MySQL specific event fields.
 
@@ -704,7 +704,7 @@ The error info message returned by MySQL.
 
 
 [[exported-fields-pgsql]]
-=== PostgreSQL fields
+=== PostgreSQL Fields
 
 PostgreSQL specific event fields.
 
@@ -746,7 +746,7 @@ In case of a successful ``SELECT`` query, it is set to the number of rows return
 
 
 [[exported-fields-thrift]]
-=== Thrift-RPC fields
+=== Thrift-RPC Fields
 
 Thrift-RPC specific event fields.
 
@@ -772,7 +772,7 @@ If the call resulted in exceptions, this field contains them in a human readable
 
 
 [[exported-fields-redis]]
-=== Redis fields
+=== Redis Fields
 
 Redis specific event fields.
 
@@ -788,7 +788,7 @@ If the Redis command has resulted in an error, this field contains the error mes
 
 
 [[exported-fields-mongodb]]
-=== MongoDb fields
+=== MongoDb Fields
 
 MongoDB specific event fields. These fields mirror closely the fields for the MongoDB wire protocol. The higher level fields (e.g. `query`, `resource`) apply to MongoDB events as well.
 
@@ -856,7 +856,7 @@ Cursor identifier that came in the OP_REPLY. This must be the value that came fr
 
 
 [[exported-fields-measurements]]
-=== Measurements fields
+=== Measurements Fields
 
 These fields contain measurements related to the transaction.
 
@@ -918,7 +918,7 @@ In RUM (real-user-monitoring), the total time it takes for the DOM to be loaded.
 
 
 [[exported-fields-env]]
-=== Environmental fields
+=== Environmental Fields
 
 These fields contain data about the environment in which the transaction was captured.
 
@@ -926,7 +926,7 @@ These fields contain data about the environment in which the transaction was cap
 
 ==== shipper
 
-The name of the shipper that captured the transaction.
+The name of the Beat that captured the transaction.
 
 
 ==== server
@@ -1018,11 +1018,11 @@ The software release of the service serving the transaction. This can be the com
 
 ==== tags
 
-Arbitrary tags that can be set per shipper and per transaction type.
+Arbitrary tags that can be set per Beat and per transaction type.
 
 
 [[exported-fields-raw]]
-=== Raw fields
+=== Raw Fields
 
 These fields contain the raw transaction data.
 

--- a/docs/filtering.asciidoc
+++ b/docs/filtering.asciidoc
@@ -1,4 +1,4 @@
-== Kibana query and filter
+== Kibana Query and Filter
 
 === Kibana Query
 
@@ -41,7 +41,7 @@ To search for all transactions with the "chunked" encoding:
 "Transfer-Encoding: chunked"
 -----------------------------
 
-==== Field based Query
+==== Field-based Query
 
 To only view HTTP transactions:
 

--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -15,7 +15,7 @@ After you have installed these products, you can start <<packetbeat-installation
 [[packetbeat-installation]]
 === Installing Packetbeat
 
-To download and install Packetbeat shippers on your application servers, run the following commands. Use the commands that work with your system (deb for Debian/Ubuntu, rpm for Redhat/Centos/Fedora, mac for OS X).
+To download and install Packetbeat on your application servers, run the following commands. Use the commands that work with your system (deb for Debian/Ubuntu, rpm for Redhat/Centos/Fedora, mac for OS X).
 
 deb:
 
@@ -53,7 +53,7 @@ https://www.elastic.co/downloads/beats/packetbeat[download page].
 NOTE: If you plan to use Logstash, you need to set up Logstash to work with the Beat before you 
 configure Packetbeat. For detailed steps, see {libbeat}/getting-started.html#logstash-setup[Setting Up Logstash].
 
-Before starting the shipper, edit the configuration file. For rpm and deb, you'll 
+Before starting Packetbeat, edit the configuration file. For rpm and deb, you'll 
 find the configuration file at `/etc/packetbeat/packetbeat.yml`. For mac, look in 
 the archive that you just downloaded.
 
@@ -104,7 +104,7 @@ protocols:
     ports: [9090]
 ----------------------------------------------------------------------
 +
-. Set the IP address and port where the shipper can find the Elasticsearch
+. Set the IP address and port where Packetbeat can find the Elasticsearch
 installation:
 +
 [source,yaml]

--- a/docs/https.asciidoc
+++ b/docs/https.asciidoc
@@ -1,4 +1,4 @@
-== Using HTTPS and basic authentication
+== Using HTTPS and Basic Authentication
 
 To secure the communication between Packetbeat and Elasticsearch, you can use HTTPS and basic authentication. Here is an
 sample configuration:
@@ -31,7 +31,7 @@ the Shield's guide.
 Packetbeat uses the list of trusted certificate authorities from the host it is running on. Please see the documentation
 for your operating system for details on how to import your own CA certificate.
 
-NOTE: The TLS handshake fails in case the SSL/TLS ceritificates have a subject which does not match the `hosts` value,
+NOTE: The TLS handshake fails in case the SSL/TLS certificates have a subject which does not match the `hosts` value,
 for any given connection. For example, if you have `hosts: ["foobar:9200"]`, then the certificate MUST include
 `CN=foobar` in the subject or subject-alternative. Make sure the hostname resolves to the desired IP address. If no DNS
 is available, then you can just associate the right IP address with your hostname in `/etc/hosts` (on Unix systems).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Packetbeat reference
+= Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.0.0-rc1
 :version: 1.0.0-rc1
 

--- a/docs/kibana3.asciidoc
+++ b/docs/kibana3.asciidoc
@@ -1,4 +1,4 @@
-== Topology diagram
+== Topology Diagram
 
 We currently recommend using Kibana 4 together with Packetbeat. However, there
 is one panel type that is not yet available for Kibana 4, namely the topology
@@ -12,7 +12,7 @@ This page walks you through the steps required to install the forked Kibana 3
 version and load the Packetbeat dashboards for it. You can install it side by
 side with Kibana 4.
 
-=== Download the Kibana 3 fork
+=== Download the Kibana 3 Fork
 
 Download the forked Kibana like this:
 
@@ -64,7 +64,7 @@ sudo /etc/init.d/elasticsearch restart
 And try again to access Kibana in your browser. You should now see
 Kibana's welcoming page.
 
-=== Load Packetbeat dashboards
+=== Load Packetbeat Dashboards
 
 To load our sample Kibana 3 dashboards, follow these steps:
 

--- a/docs/new_protocol.asciidoc
+++ b/docs/new_protocol.asciidoc
@@ -1,9 +1,9 @@
-== Developer guide: adding a new protocol
+== Developer Guide: Adding a New Protocol
 
 This guide walks you through the steps needed to add a new protocol to
 Packetbeat.
 
-=== Getting ready
+=== Getting Ready
 
 Packetbeat is written in http://golang.org/[Go], so having it installed and
 knowing its basics is a prerequisite for adding a new protocol. However, don't
@@ -27,7 +27,7 @@ Before starting, please also read the
 https://github.com/elastic/packetbeat/blob/master/CONTRIBUTING.md[CONTRIBUTING]
 file on Github.
 
-==== Cloning and compiling
+==== Cloning and Compiling
 
 After having https://golang.org/doc/install[installed Go] and having setup the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
@@ -53,7 +53,7 @@ Note that the location where you clone is important. If you prefer working
 outside of the `GOPATH` environment, you can clone to another directory and only
 create a symlink it to the `$GOPATH/src/github.com/elastic/` directory.
 
-==== Fork and branch
+==== Forking and Branching
 
 We recommend the following work flow for contributing to Packetbeat:
 
@@ -86,7 +86,7 @@ $ git push --set-upstream tsg cool_new_protocol
   the branch after creating the PR. Submitting it early gives us more time to
   provide feedback and perhaps help you with it.
 
-==== A note about dependencies
+==== A Note About Dependencies
 
 Packetbeat uses https://github.com/tools/godep[Godep] for vendoring its
 dependencies. The way Godep works is that it copies the source code of all
@@ -98,7 +98,7 @@ helps with validating code as you type.
 If you add a new dependency, you can use `godep get` to add it to the vendored
 folder.
 
-=== Protocol modules
+=== Protocol Modules
 
 Packetbeat's source code is split up in Go packages or modules. The protocol
 modules can be found in individual folders the
@@ -189,7 +189,7 @@ decisions about what to do with partial data received. For example, for the
 HTTP/1.0 protocol, the end of connection is used to know when the message is
 finished.
 
-==== Registering your plugin
+==== Registering Your Plugin
 
 To Configure your plugin you have to add a configuration struct to 
 `config/config.go` Protocols struct. This struct will be filled by
@@ -240,7 +240,8 @@ var ProtocolNames = []string{
 }
 ----------------------------------------------------------------------
 
-Protocol names order must match the protocol IDs. Additionally the protocol name must match the configuration name.
+Protocol names order must match the protocol IDs. Additionally the protocol name 
+must match the configuration name.
 
 Finally register your new protocol plugin in `packetbeat.go` EnabledProtocolPlugins:
 
@@ -267,7 +268,7 @@ helpful to first register it and implement the minimal plugin interface printing
 a debug message on received packets. This way you can test plugin registration
 working correctly.
 
-==== The TCP Parse function
+==== The TCP Parse Function
 
 For TCP protocols, the `Parse()` function is the heart of the module. As
 mentioned before, it is called for every TCP packet containing data on the
@@ -365,7 +366,7 @@ data. Finally, if the message is complete, we go to the next level.
 This block of code is called in a loop so that it can separate multiple messages
 found in the same packet.
 
-==== The UDP ParseUdp function
+==== The UDP ParseUdp Function
 
 If the protocol you are working on is running on top of UDP, then all the
 complexities around extracting messages from packets that the TCP
@@ -394,7 +395,7 @@ this map incomplete transactions. For example, we might see the request that has
 created an entry in the map, but if we never see the reply, we need to remove
 the request from memory on a timer, otherwise we risk leaking memory.
 
-==== Send the result
+==== Send the Result
 
 After the correlation step, you should have an JSON like object that can be sent
 to Elasticsearch for indexing. The way you do that is by publishing it
@@ -453,7 +454,7 @@ system tests:
 
 ==== Helpers
 
-===== Parsing helpers
+===== Parsing Helpers
 
 In libbeat you also find some helpers for implementing parsers for binary and
 text based protocols. The `Bytes_*` functions being the most low level helpers
@@ -533,7 +534,7 @@ It also implements a number of interfaces defined in the standard "io" package
 and can easily be used to serialize some packets for testing parsers (see
 `protos/memcache/binary_test.go`).
 
-===== Module helpers
+===== Module Helpers
 
 Packetbeat provides the module `packetbeat/protos/applayer` with
 common definitions among all application layer protocols. For example using the
@@ -573,7 +574,7 @@ transaction and `applayer.Stream` to manage your stream buffers for parsing.
 
 === Testing
 
-==== Unit tests
+==== Unit Tests
 
 For unit tests, use only the Go standard library
 http://golang.org/pkg/testing/[testing] package. To make comparing complex
@@ -656,7 +657,7 @@ there's no transaction present.
 To check the coverage of your unit tests, run the `make cover` command at the
 top of the repository.
 
-==== Sytem testing
+==== System Testing
 
 Because the main input to Packetbeat are packets and the main output are JSON
 objects, a convenient way of testing its functionality is by providing PCAP

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -14,30 +14,30 @@ Packetbeat can help you easily notice issues with your back-end application, suc
 or performance problems, and it makes troubleshooting them - and therefore
 fixing them - much faster.
 
-Packetbeat shippers sniff the traffic between your servers, parse the
-application-level protocols on the fly, and correlate the messages into transactions.
-Currently, the Packetbeat shipper supports the following protocols:
+Packetbeat sniffs the traffic between your servers, parses the
+application-level protocols on the fly, and correlates the messages into transactions.
+Currently, Packetbeat supports the following protocols:
 
  * HTTP
  * MySQL
  * PostgreSQL
  * Redis
  * Thrift-RPC
- * Mongodb
+ * MongoDB
  * DNS
  * Memcache
 
-The shippers can insert the correlated transactions directly into Elasticsearch
-or into a central queue created with Redis and Logstash.
+Packetbeat can insert the correlated transactions directly into Elasticsearch
+or into a central queue created with Redis (DEPRECATED) and Logstash. 
 
-Packetbeat shippers can run on the same servers as your application processes or
-on their own servers. When running on dedicated servers, the shippers can get the
+Packetbeat can run on the same servers as your application processes or
+on its own servers. When running on dedicated servers, Packetbeat can get the
 traffic from the switch's mirror ports or from tapping devices. In such a
 deployment, there is zero overhead on the monitored application. See
 <<capturing-options>> for details.
 
 After decoding the Layer 7 messages, Packetbeat correlates the requests with
-the responses in what we call "transactions." For each transaction, Packetbeat 
+the responses in what we call _transactions_. For each transaction, Packetbeat 
 inserts a JSON document into Elasticsearch. See the <<exported-fields>> section
 for details about which fields are indexed.
 

--- a/docs/thrift.asciidoc
+++ b/docs/thrift.asciidoc
@@ -1,4 +1,4 @@
-== Thrift-RPC support
+== Thrift-RPC Support
 
 https://thrift.apache.org/[Apache Thrift] is a communication protocol and RPC
 framework initially created at Facebook. It is sometimes used in
@@ -32,7 +32,7 @@ and protocol types]. Currently Packetbeat supports the default `TSocket`
 transport as well as the `TFramed` transport. From the protocol point of view,
 Packetbeat currently supports only the default `TBinary` protocol.
 
-The Packetbeat shipper also has several configuration options allowing you to get
+Packetbeat also has several configuration options allowing you to get
 the right balance between visibility and disk usage / data protection. You can
 for example, choose to obfuscate all strings or to store the requests but not
 the responses, while still capturing the response time for each of the RPC
@@ -59,7 +59,7 @@ protocols:
 More details about the configuration options can be found in the
 <<configuration-thrift>> section.
 
-Providing the Thrift IDL files to the Packetbeat shipper is optional. The binary
+Providing the Thrift IDL files to Packetbeat is optional. The binary
 Thrift messages include the called method name and enough structure information
 to decode the messages without the need of the IDL files. However, if you
 provide the IDL files, Packetbeat can also resolve the service name, the

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -1,6 +1,6 @@
 == Troubleshooting
 
-If you suspect an issue with the Packetbeat shipper itself, please read the
+If you suspect an issue with Packetbeat, please read the
 following tips and send us the logs and, if possible, a traffic trace.
 
 Please contact us on the https://discuss.elastic.co/c/beats/packetbeat[forums].
@@ -11,7 +11,7 @@ https://github.com/elastic/packetbeat/issues?state=open[GitHub]. Note, however,
 that we close GitHub issues if they are questions or requests for help that
 don't indicate the presence of a bug.
 
-=== Running in foreground and enabling debugging
+=== Running in the Foreground and Enabling Debugging
 
 By default, Packetbeat sends all its output to syslog. You can use the `-e`
 command line flag to direct the output at standard error instead:
@@ -30,7 +30,7 @@ packetbeat -e -c /etc/packetbeat/packetbeat.yml
 ------------------------------------------------------------
 
 You can increase the verbosity by enabling one or more debug selectors. For
-example, to view which transactions are published, you can start the shipper like
+example, to view which transactions are published, you can start Packetbeat like
 this:
 
 [source,shell]
@@ -74,7 +74,7 @@ use `*`, like this:
 packetbeat -e -d "*"
 ------------------------------------------------------------
 
-=== Recording a trace
+=== Recording a Trace
 
 If you are having an issue, it is often useful to record a full network trace
 and send it to us. It will help us reproduce the issue and we can also add it

--- a/docs/windows.asciidoc
+++ b/docs/windows.asciidoc
@@ -1,5 +1,5 @@
 
-== Windows support
+== Windows Support
 
 This page walks you through the steps required for running Packetbeat on
 Windows. It assumes your Windows system has Powershell installed.

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -15,7 +15,7 @@ env:
   fields:
     - name: shipper
       description: >
-          The name of the shipper that captured the transaction.
+          The name of the Beat that captured the transaction.
 
     - name: server
       description: >
@@ -93,7 +93,7 @@ env:
 
     - name: tags
       description: >
-        Arbitrary tags that can be set per shipper and per transaction
+        Arbitrary tags that can be set per Beat and per transaction
         type.
 
 event:
@@ -107,7 +107,7 @@ event:
       format: YYYY-MM-DDTHH:MM:SS.milliZ
       example: 2015-01-24T14:06:05.071Z
       description: >
-        The timestamp of the event, as measured either by the shipper or
+        The timestamp of the event, as measured either by the Beat or
         by a common collector point. The precision is in milliseconds.
         The timezone is UTC.
 

--- a/scripts/generate_field_docs.py
+++ b/scripts/generate_field_docs.py
@@ -28,7 +28,7 @@ def document_fields(output, section):
 
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
-    output.write("=== {} fields\n\n".format(section["name"]))
+    output.write("=== {} Fields\n\n".format(section["name"]))
 
     if "description" in section:
         output.write("{}\n\n".format(section["description"]))
@@ -72,10 +72,10 @@ This file is generated! See etc/fields.yml and scripts/generate_field_docs.py
 ////
 
 [[exported-fields]]
-== Exported fields
+== Exported Fields
 
-This document describes the fields that are exported by the
-Packetbeat shipper for each transaction. They are grouped in the
+This document describes the fields that are exported by 
+Packetbeat for each transaction. They are grouped in the
 following categories:
 
 """)


### PR DESCRIPTION
Implements terminology change for Packetbeat that is discussed in https://github.com/elastic/libbeat/issues/255. Also includes some very minor edits for consistency.