### PR TITLE
Implements technical edits to Packetbeat config topics

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -276,7 +276,7 @@ The per protocol transaction timeout. Expired transactions will no longer be cor
 
 ==== DNS Configuration Options
 
-The `dns` section specifies configuration options for the DNS protocol. The DNS protocol supports processing DNS message on UDP. Here is a sample configuration section for DNS:
+The `dns` section specifies configuration options for the DNS protocol. The DNS protocol supports processing DNS messages on UDP. Here is a sample configuration section for DNS:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -352,7 +352,7 @@ WARNING: This option replaces query parameters from GET requests and top-level
 parameters from POST requests. If sensitive data is encoded inside a
 parameter that you don't specify here, Packetbeat cannot censor it. Also, note that if
 you configure Packetbeat to save the raw request and response fields (see the <<send-request-option>>
-and the <<send-response-option>> options), the sensitive data will be present in those
+and the <<send-response-option>> options), sensitive data may be present in those
 fields.
 
 
@@ -449,7 +449,7 @@ fields.
 
 When this option is enabled, it forces the memcache text protocol parser to accept unknown commands.
 
-NOTE: Unknown commands MUST NOT contain a data part.
+NOTE: The unknown commands MUST NOT contain a data part.
 
 ===== maxvalues
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,26 +1,27 @@
 [[packetbeat-configuration]]
 == Configuration Options
 
-The Packetbeat configuration file uses http://yaml.org/[YAML] as any other Beat. 
-It consists of the following sections:
+The Packetbeat configuration file uses http://yaml.org/[YAML] for its syntax. 
+The file consists of the following sections:
 
 
-* {libbeat}/configuration.html#configuration-shipper[Shipper] (this section is covered in the
-{libbeat}/configuration.html#configuration-shipper[Beats Platform Reference])
+* {libbeat}/configuration.html#configuration-shipper[Shipper]
 * <<configuration-interfaces>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
-* {libbeat}/configuration.html#configuration-output[Output]
-* {libbeat}/configuration.html#configuration-run-options[Run options (optional)]
+* {libbeat}/configuration.html#configuration-output[Output] 
+* {libbeat}/configuration.html#configuration-run-options[Run Options (Optional)]
 
-NOTE: Packetbeat maintains in real-time a topology map with all the servers from your network. 
-Check <<maintaining-topology>> for more details.
+The `shipper`, `output`, and `runoptions` sections contain configuration options that are common to all 
+Beats, so they are covered in the {libbeat}/configuration.html[Beats Platform Reference].
+
+NOTE: Packetbeat maintains a real-time topology map of all the servers in your network. 
+See <<maintaining-topology>> for more details.
 
 [[configuration-interfaces]]
 === Interfaces
 
-The `interfaces` section configures the sniffer. Here is a sample
-configuration:
+The `interfaces` section configures the sniffer. Here is an example configuration:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -44,9 +45,10 @@ interfaces:
 
 ===== device
 
-Configures the network devices from which the traffic is
-captured. The configured device is set automatically in promiscuous mode,
-meaning that it can capture traffic from other hosts of the same LAN.
+The network device to capture traffic from. The specified device is set automatically to promiscuous mode,
+meaning that Packetbeat can capture traffic from other hosts on the same LAN.
+
+Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -54,18 +56,38 @@ interfaces:
   device: eth0
 ------------------------------------------------------------------------------
 
-Alternatively, on Linux Packetbeat supports capturing of all
-messages sent or received by the server on which it is installed. For this, use
-the special "any" device.
+On Linux, you can specify `any` for the device, and Packetbeat captures all
+messages sent or received by the server where Packetbeat is installed. 
 
-NOTE: When using the "any" device, the interfaces are not set
-      in promiscuous mode.
+NOTE: When you specify `any` for the device, the interfaces are not set
+      to promiscuous mode.
 
-This option also accepts specifying the device by its index in the list of
-devices available for sniffing. To obtain the list of available devices, you can
-use run Packetbeat like this: `packetbeat -devices`. This is especially useful
-on Windows where device names are long. The following example will setup
-sniffing on the first interface available:
+The `device` option also accepts specifying the device by its index in the list of
+devices available for sniffing. To obtain the list of available devices, 
+run Packetbeat with the following command: 
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+packetbeat -devices
+----------------------------------------------------------------------
+
+This command returns a list that looks something like the following:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+0: en0 (No description available)
+1: awdl0 (No description available)
+2: bridge0 (No description available)
+3: fw0 (No description available)
+4: en1 (No description available)
+5: en2 (No description available)
+6: p2p0 (No description available)
+7: en4 (No description available)
+8: lo0 (No description available)
+----------------------------------------------------------------------
+
+The following example sets up sniffing on the 
+first interface in the list:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -73,14 +95,16 @@ interfaces:
   device: 0
 ------------------------------------------------------------------------------
 
+Specifying the index is especially useful on Windows where device names can be long. 
 
 ===== snaplen
 
-The *snaplen* option controls the maximum size of the packets to capture. The
-default is 65535 which is large enough for almost all networks and interfaces
-types. If you sniff on a physical network interface, you can optimize this by
-setting it to the MTU size. On virtual interfaces, however, it's safer to leave
-this to the default value.
+The maximum size of the packets to capture. The
+default is 65535, which is large enough for almost all networks and interface 
+types. If you sniff on a physical network interface, the optimal setting is  
+the MTU size. On virtual interfaces, however, it's safer to accept the default value.
+
+Example: 
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -93,16 +117,18 @@ interfaces:
 
 Packetbeat supports three sniffer types:
 
- * `pcap` which uses the libpcap library and works on most platforms, but
+ * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.
- * `af_paket` which uses memory mapped sniffing. It is faster than libpcap
-   and doesn't require a kernel module, but it is Linux specific.
- * `pf_ring` which makes use of an ntop.org
-   http://www.ntop.org/products/pf_ring/[project]. This will get you the best
-   sniffing speed but requires a kernel module and is Linux specific.
+ * `af_packet`, which uses memory-mapped sniffing. This option is faster than libpcap
+   and doesn't require a kernel module, but it's Linux-specific.
+ * `pf_ring`, which makes use of an ntop.org
+   http://www.ntop.org/products/pf_ring/[project]. This setting provides the best
+   sniffing speed, but it requires a kernel module, and it's Linux-specific.
 
-The default sniffer is `pcap`. Here is an example configuration that switches
-to the `af_packet` sniffing type:
+The default sniffer type is `pcap`. 
+
+Here is an example configuration that specifies 
+the `af_packet` sniffing type:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -111,20 +137,21 @@ interfaces:
   type: af_packet
 ------------------------------------------------------------------------------
 
-If you are on Linux and you are trying to optimize the CPU usage of Packetbeat,
-we recommend trying the `af_packet` and `pf_ring` options. Read this
-http://packetbeat.com/blog/sniffing-performance-and-ipv6.html[blog post]
-for some details.
+On Linux, if you are trying to optimize the CPU usage of Packetbeat, 
+we recommend trying the `af_packet` and `pf_ring` options. Read <<capturing-options>>
+for more details.
 
-If you use the `af_packet` sniffer, you can tune its behaviour with the
+If you use the `af_packet` sniffer, you can tune its behaviour by specifying the
 following options:
 
 ===== buffer_size_mb
 
-This option controls the maximum size of the shared memory buffer to use
+The maximum size of the shared memory buffer to use
 between the kernel and user space. A bigger buffer usually results in lower CPU
 usage, but consumes more memory. This setting is only available for the
 `af_packet` sniffer type. The default is 30 MB.
+
+Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -137,25 +164,25 @@ interfaces:
 ===== with_vlans
 
 Packetbeat automatically generates a
-https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
-the traffic on the ports on which the known protocols are expected to be found.
+https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only 
+the traffic on ports where it expects to find known protocols. 
 For example, if you have configured port 80 for HTTP and port 3306 for MySQL,
-Packetbeat will generate the following BPF filter: `"port 80 or port 3306"`.
+Packetbeat generates the following BPF filter: `"port 80 or port 3306"`.
 
 However, if the traffic contains https://en.wikipedia.org/wiki/IEEE_802.1Q[VLAN]
-tags, the above filter is ineffective because the offset used are moved with
-four bytes. To fix this, you can enabled the `with_vlans` option, which will
-generate a BPF filter looking like this: `"port 80 or port 3306 or (vlan and (port 80 or port 3306))"`.
+tags, the filter that Packetbeat generates is ineffective because the 
+offset is moved by four bytes. To fix this, you can enable the `with_vlans` option, which 
+generates a BPF filter that looks like this: `"port 80 or port 3306 or (vlan and (port 80 or port 3306))"`.
 
 ===== bpf_filter
 
 Packetbeat automatically generates a
-https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only
-the traffic on the ports on which the known protocols are expected to be found.
+https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] for capturing only 
+the traffic on ports where it expects to find known protocols. 
 For example, if you have configured port 80 for HTTP and port 3306 for MySQL,
-Packetbeat will generate the following BPF filter: `"port 80 or port 3306"`.
+Packetbeat generates the following BPF filter: `"port 80 or port 3306"`.
 
-With this setting, you can overwrite the generated BPF filter. For example:
+You can use the `bpf_filter` setting to overwrite the generated BPF filter. For example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -164,16 +191,16 @@ interfaces:
   bpf_filter: "net 192.168.238.0/0 and port 80 and port 3306"
 ------------------------------------------------------------------------------
 
-Note that this setting disables the automatic generation of the BPF filter so if
-you use it, it is your responsibility to keep the BPF filters in sync with the
-ports defined in the protocols sections.
+NOTE: This setting disables automatic generation of the BPF filter. If 
+you use this setting, it's your responsibility to keep the BPF filters in sync with the
+ports defined in the `protocols` section.
 
 
 [[configuration-protocols]]
 === Protocols
 
-A section for each supported protocol is defined to configure options like
-`ports`, `send_request`, `send_response` or options that are protocol specific.
+The `protocols` section contains configuration options for each supported protocol, including 
+common options like `ports`, `send_request`, `send_response`, and options that are protocol-specific.
 
 Currently, Packetbeat supports the following protocols:
 
@@ -219,34 +246,37 @@ The following options are available for all protocols:
 
 ===== ports
 
-Packetbeat installs a BPF filter based on the ports configured in
-this section.
+The ports where Packetbeat will look to capture traffic for specific 
+protocols. Packetbeat installs a https://en.wikipedia.org/wiki/Berkeley_Packet_Filter[BPF] 
+filter based on the ports specified in this section.
 If a packet doesn't match the filter, very little CPU is required to discard
-the packet. Packetbeat also uses the ports configured here to decide which
+the packet. Packetbeat also uses the ports specified here to determine which
 parser to use for each packet.
 
+[[send-request-option]]
 ===== send_request
 
 If this option is enabled, the raw message of the request (`request` field) is
-sent to Elasticsearch. The default is false. This is useful in case you want to
+sent to Elasticsearch. The default is false. This option is useful when you want to
 index the whole request. Note that for HTTP, the body is not included by
 default, only the HTTP headers.
 
+[[send-response-option]]
 ===== send_response
 
 If this option is enabled, the raw message of the response (`response` field)
-is sent to Elasticsearch. The default is false.  This is useful in case you
+is sent to Elasticsearch. The default is false.  This option is useful when you 
 want to index the whole request. Note that for HTTP, the body is not included
 by default, only the HTTP headers.
 
 ===== transaction_timeout
 
-Per protocol transaction timeout. Expired transaction won't be correlated to incoming responses anymore, but sent to Elasticsearch immediately.
+The per protocol transaction timeout. Expired transactions will no longer be correlated to incoming responses, but sent to Elasticsearch immediately.
 
 
-==== DNS Configuration
+==== DNS Configuration Options
 
-DNS protocol supports processing DNS message on UDP. Here is a sample configuration section for DNS:
+The `dns` section specifies configuration options for the DNS protocol. The DNS protocol supports processing DNS message on UDP. Here is a sample configuration section for DNS:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -266,17 +296,17 @@ protocols:
 
 ===== include_authorities
 
-If enabled dns.authority fields (authority resource records) are added to DNS events.
-By default publishing authority data is disabled.
+If this option is enabled, dns.authority fields (authority resource records) are added to DNS events.
+The default is false.
 
 ===== include_additionals
 
-If enabled dns.additionals field (additional resource records) are added to DNS events.
-By default publishing additional resource records is disabled.
+If this option is enabled, dns.additionals fields (additional resource records) are added to DNS events.
+The default is false.
 
-==== HTTP Configuration
+==== HTTP Configuration Options
 
-The Http protocol has several specific configuration options. Here is a
+The HTTP protocol has several specific configuration options. Here is a
 sample configuration section:
 
 [source,yaml]
@@ -309,43 +339,46 @@ protocols:
 
 ===== hide_keywords
 
-Packetbeat has the option of automatically censor certain strings
-from the transactions it saves. This is done because while the SQL traffic
-typically only contains the hashes of the passwords, it is possible that the
-HTTP traffic contains sensitive data. In order to reduce the security risks, 
-Packetbeat can automatically avoid sending the contents of certain HTTP POST
-parameters. The sensitive content associated with these keywords is replaced
-by ``xxxxx``. By default, no changes are made to the HTTP messages.
+A list of query parameters that Packetbeat will automatically censor in 
+the transactions that it saves. The values associated with these parameters are replaced
+by `'xxxxx'`. By default, no changes are made to the HTTP messages.
 
-WARNING: This option replaces query parameters from GET requests and top level
-parameters from POST requests. If the sensitive data is encoded inside a
-parameter with a different name, we cannot censor it there. Also, note that if
-you enable saving the raw request and response fields (see the `send_requset`
-and the `send_response` options), the sensitive data will be present in those
+Packbeat has this option because, unlike SQL traffic, which typically only contains the 
+hashes of the passwords, HTTP traffic may contain sensitive data. To reduce security risks, 
+you can configure this option to avoid sending the contents of certain HTTP POST 
+parameters.
+
+WARNING: This option replaces query parameters from GET requests and top-level
+parameters from POST requests. If sensitive data is encoded inside a
+parameter that you don't specify here, Packetbeat cannot censor it. Also, note that if
+you configure Packetbeat to save the raw request and response fields (see the <<send-request-option>>
+and the <<send-response-option>> options), the sensitive data will be present in those
 fields.
+
 
 ===== redact_authorization
 
-If the transactions that are being observed use Basic Authentication
-then the exchange contains the base64 unencrypted username and
-password.  Enabling `redact_authorization` obscures the value of the
+When this option is enabled, Packetbeat obscures the value of 
 `Authorization` and `Proxy-Authorization` HTTP headers, and censors
 those strings in the response.
 
+You should set this option to true for transactions that use Basic Authentication because 
+they may contain the base64 unencrypted username and password. 
+
 ===== send_headers
 
-A list of header names to be captured and send to Elasticsearch. These
+A list of header names to capture and send to Elasticsearch. These
 headers are placed under the `headers` dictionary in the resulting JSON.
 
 ===== send_all_headers
 
-Alternatively to sending a white list of headers to Elasticsearch, you can
+Instead of sending a white list of headers to Elasticsearch, you can
 send all headers by setting this option to true. The default is false.
 
 ===== include_body_for
 
 The list of content types for which Packetbeat includes the full HTTP payload in
-the `response` field. Should be used together with the `send_response` option.
+the `response` field. This option should be used together with the <<send-response-option>> option.
 
 Example configuration:
 
@@ -362,7 +395,7 @@ protocols:
 ===== split_cookie
 
 If the `Cookie` or `Set-Cookie` headers are sent, this option controls whether
-they are split into individual values. For example, with this option set, a
+they are split into individual values. For example, with this option set, an 
 HTTP response might result in the following JSON:
 
 [source,json]
@@ -387,19 +420,19 @@ HTTP response might result in the following JSON:
 }
 ------------------------------------------------------------------------------
 
-<1> Note that `set-cookie` is a map having the cookie names as keys.
+<1> Note that `set-cookie` is a map containing the cookie names as keys.
 
 The default is false.
 
 ===== real_ip_header
 
-The header field to extract the real IP from. This is often useful when
-capturing behind a reverse proxy and still wanting to get the geo-location
+The header field to extract the real IP from. This setting is useful when
+you want to capture traffic behind a reverse proxy, but you want to get the geo-location
 information. If this header is present and contains a valid IP addresses, the
 information is used for the `real_ip` and `client_location` indexed
 fields.
 
-==== Memcache Configuration
+==== Memcache Configuration Options
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -414,55 +447,55 @@ fields.
 
 ===== parseunknown
 
-Force memcache text protocol parser to accept unknown commands.
-Note: All unknown commands MUST NOT contain a data part.
+When this option is enabled, it forces the memcache text protocol parser to accept unknown commands.
+
+NOTE: Unknown commands MUST NOT contain a data part.
 
 ===== maxvalues
 
-Maximum number of values to store in message (multi-get).
+The maximum number of values to store in the message (multi-get).
 All values will be base64 encoded.
 
-possible values:
-  maxvalue: -1  - store all values (text based protocol multi-get)
-  maxvalue: 0   - store no values at all (default)
-  maxvalue: N   - store up to N values
+The possible settings for this option are:
+
+* `maxvalue: -1`, which stores all values (text based protocol multi-get)
+* `maxvalue: 0`, which stores no values (default)
+* `maxvalue: N`, which stores up to N values
 
 ===== maxbytespervalue
 
-Limit the number of bytes to be copied per value element.
+The maximum number of bytes to be copied for each value element.
 
-Note:
-Values will be base64 encoded, so actual size in json document will be 4 times
-maxbytespervalue.
+NOTE: Values will be base64 encoded, so the actual size in the JSON document will be 4 times the value that 
+you specify for `maxbytespervalue`.
 
 ===== udptransactiontimeout
 
-Transaction timeout in milliseconds. Defaults to 10000 milliseconds.
+The transaction timeout in milliseconds. The defaults is 10000 milliseconds.
 
-Note:
-Quiet messages in UDP binary protocol will get response only in error case.
-The memcache protocol analyzer will wait for udptransactiontimeout milliseconds
-before publishing quiet messages. Non quiet messages or quiet requests with
-error response will not have to wait for the timeout.
+NOTE: Quiet messages in UDP binary protocol get responses only if there is an error. 
+The memcache protocol analyzer will wait for the number of milliseconds specified by 
+`udptransactiontimeout` before publishing quiet messages. Non-quiet messages or 
+quiet requests with an error response are published immediately.
 
 
-==== MySQL and PgSQL Configuration
+==== MySQL and PgSQL Configuration Options
 
 ===== max_rows
 
-Maximum number of rows from the SQL message to publish to Elasticsearch. The
-default is 10 rows in order to publish data as little as needed.
+The maximum number of rows from the SQL message to publish to Elasticsearch. The
+default is 10 rows.
 
 
 ===== max_row_length
 
-Maximum length in bytes of a row from the SQL message to publish to
+The maximum length in bytes of a row from the SQL message to publish to
 Elasticsearch. The default is 1024 bytes.
 
 [[configuration-thrift]]
-==== Thrift Configuration
+==== Thrift Configuration Options
 
-Thrift protocol has several specific configuration options. Here is a
+The Thrift protocol has several specific configuration options. Here is a
 sample configuration section:
 
 [source,yaml]
@@ -480,51 +513,52 @@ sample configuration section:
 
 ===== transport_type
 
-Thrift transport type. Currently this option accepts the options `socket`
-for TSocket which is the default Thrift transport and `framed` which
-corresponds to the TFramed Thrift transport. The default is `socket`.
+The Thrift transport type. Currently this option accepts the values `socket`  
+for TSocket, which is the default Thrift transport, and `framed` for the TFramed Thrift 
+transport. The default is `socket`.
 
 ===== protocol_type
 
-Thrift protocol type. Currently the only accepted value is `binary`
-corresponding to the TBinary protocol, which is the default Thrift protocol.
+The Thrift protocol type. Currently the only accepted value is `binary` for 
+the TBinary protocol, which is the default Thrift protocol.
 
 ===== idl_files
 
-The Thrift Interface description language (IDL) files for the service that 
+The Thrift interface description language (IDL) files for the service that 
 Packetbeat is monitoring. Providing the IDL files is optional, because the Thrift
 messages contain enough information to decode them without having the IDL
-files. However, providing the IDL will additionally fill in parameter and
-exceptions names.
+files. However, providing the IDL enables Packetbeat to include parameter and
+exception names.
 
 ===== string_max_size
 
-If a string from one of the parameters or from the return value is longer than
-this value, the string is automatically truncated to this length. Dots are added
+The maximum length for strings in parameters or return values. If a string is longer than
+this value, the string is automatically truncated to this length. Packetbeat adds dots 
 at the end of the string to mark that it was truncated. The default is 200.
 
 ===== collection_max_size
 
-If a Thrift list, set, map or structure has more elements than this value, only
-this many number of elements will be captured. A fictive last element `...` is
-added at the end to mark that the collection was truncated. The default is 15.
+The maximum number of elements in a Thrift list, set, map, or structure. If a collection 
+has more elements than this value, Packetbeat captures only the 
+specified number of elements. Packetbeat adds a fictive last element `...` to the end 
+of the collection to mark that it was truncated. The default is 15.
 
 ===== capture_reply
 
-If set to false, Packetbeat only decodes the method name from
-the reply and simply skip the rest of the response message. This can be useful
-for performance, disk usage or data retention reasons. The default is true.
+If this option is set to false, Packetbeat decodes the method name from
+the reply and simply skips the rest of the response message. This setting can be useful
+for performance, disk usage, or data retention reasons. The default is true.
 
 ===== obfuscate_strings
 
-If enabled, this option replaces all strings found in the method parameters or
-in the return code or in the exception structures with the `"*"` string.
+If this option is set to true, Packetbeat replaces all strings found in method parameters, 
+return codes, or exception structures with the `"*"` string.
 
 ===== drop_after_n_struct_fields
 
-If a structure has more fields than this given value, Packetbeat will
-ignore the whole transaction. This is a memory protection mechanism (so that 
-Packetbeat's memory doesn't grow indefinitely), so you would topically set this
+The maximum number of fields that a structure can have before Packetbeat 
+ignores the whole transaction. This is a memory protection mechanism (so that 
+Packetbeat's memory doesn't grow indefinitely), so you would typically set this
 to a relatively high value. The default is 500.
 
 
@@ -548,69 +582,59 @@ Packetbeat indexes in the `response` fields.
 
 ===== max_docs
 
-Maximum number of docs from the response to index in the `response` field. The
+The maximum number of documents from the response to index in the `response` field. The
 default is 10. You can set this to 0 to index an unlimited number of documents.
 
-A `[...]` line is added automatically at the end to signify that there were
-more documents but they weren't saved because of this setting.
+Packetbeat adds a `[...]` line at the end to signify that there were additional documents 
+that weren't saved because of this setting.
 
 ===== max_doc_length
 
-Maximum number of characters in a single document indexed in the `response`
+The maximum number of characters in a single document indexed in the `response`
 field. The default is 5000. You can set this to 0 to index an unlimited number
 of characters per document.
 
-If the document is trimmed because of this setting, the string ` ...` is added
-at the end of it.
+If the document is trimmed because of this setting, Packetbeat adds the string ` ...` 
+at the end of the document.
 
-Note that limiting documents this way means that they are no longer correctly
+Note that limiting documents in this way means that they are no longer correctly
 formatted JSON objects.
 
-
 [[maintaining-topology]]
-=== Maintaining the Real-time State of the Network Topology
+=== Maintaining the Real-Time State of the Network Topology
 
-One of the important features of Packetbeat is that it knows for each
-transaction which is the source server and is the destination server by names.
-It does this without the requirement of maintaining a central configuration.
-Instead each Beat notes the hostname of the server on which it runs, and
-maps that to the list of IP addresses of that server. This information is
-shared between Beats by using the mechanisms provided by the output plugins.
+One important feature of Packetbeat is that it knows the name of the source and 
+destination servers for each transaction. It does this without needing to maintain 
+a central configuration. Instead, each Beat notes the hostname of the server 
+where the Beat runs, and maps the hostname to the list of IP addresses of that server.
 
-For example, the Redis output plugin stores the topology in a dedicated Redis
-database and the Elasticsearch output plugin stores the topology in an
-Elasticsearch index.
-
-While multiple output plugins can be enabled at the same time, only one of them
-can be used for sharing the topology. If you have both Redis and Elasticsearch
-enabled as outputs, we suggest using Redis for saving the topology. This can be
-controlled from the `save_topology` configuration option.
-
-
+Packetbeat stores the topology information in an Elasticsearch index, so to save 
+the network topology, you need to use Elasticsearch as output and set the 
+`save_topology` configuration option to true. 
 
 [[configuration-processes]]
-=== Processes (optional)
+=== Processes (Optional)
 
 This section is optional, but configuring the processes enables Packetbeat 
-to not only show you between which servers the traffic is flowing, but
-also between which processes. It can even show you the traffic between two
-processes running on the same host, so this is particularly useful when you
-have more services running on the same server. By default, process matching
+to show you not only the servers that the traffic is flowing between, but
+also the processes. Packetbeat can even show you the traffic between two
+processes running on the same host, which is particularly useful when you
+have many services running on the same server. By default, process matching
 is disabled.
 
-When it starts (and then periodically) Packetbeat scans the process table for
-processes matching the configuration file. For each of these processes, it
+When Packetbeat starts, and then periodically afterwards, it scans the process table for
+processes that match the configuration file. For each of these processes, it
 monitors which file descriptors it has opened. When a new packet is captured,
 it reads the list of active TCP connections and matches the corresponding one
 with the list of file descriptors.
 
 On a Linux system, all this information is available via the `/proc`
-filesystem, so Packetbeat doesn't need a kernel module.
+file system, so Packetbeat doesn't need a kernel module.
 
 
 NOTE: Process monitoring is currently only supported on
       Linux systems. Packetbeat automatically disables
-      it when it detects other operating systems.
+      process monitoring when it detects other operating systems.
 
 Example configuration:
 
@@ -636,19 +660,13 @@ procs:
 
 ===== process
 
-The `process` option for each process defines the name of the process, as it
-appears in the published transactions. The name doesn't have to match the name
-of the executable, feel free to choose something more descriptive (e.g. "my
-app" instead of "gunicorn")
+The name of the process as it will appear in the published transactions. The name 
+doesn't have to match the name of the executable, so feel free to choose something 
+more descriptive (for example,  "myapp" instead of "gunicorn").
 
 ===== cmdline_grep
 
-This option for each process is used to identify the process at
-runtime. When it starts, and then periodically, Packetbeat scans the process table for
-processes matching `cmdline_grep` option. The match is done against the
+The name used to identify the process at run time. When Packetbeat starts, and then 
+periodically afterwards, it scans the process table for
+processes that match the values specified for this option. The match is done against the
 process' command line as read from `/proc/<pid>/cmdline`.
-
-For each of these processes, it monitors which file descriptors it has opened.
-When a new packet is captured, it reads the list of active TCP connections and
-matches the corresponding one with the list of file descriptors.
-

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -343,7 +343,7 @@ A list of query parameters that Packetbeat will automatically censor in
 the transactions that it saves. The values associated with these parameters are replaced
 by `'xxxxx'`. By default, no changes are made to the HTTP messages.
 
-Packbeat has this option because, unlike SQL traffic, which typically only contains the 
+Packetbeat has this option because, unlike SQL traffic, which typically only contains the 
 hashes of the passwords, HTTP traffic may contain sensitive data. To reduce security risks, 
 you can configure this option to avoid sending the contents of certain HTTP POST 
 parameters.


### PR DESCRIPTION
Technical edits to improve clarity and make the doc consistent. Network protocols and related topics aren't exactly in my "wheelhouse," so please review carefully.

BTW, I removed the following paragraph from the description of cmdline_grep because it repeated what we already say in the intro paragraph: “For each of these processes, it monitors which file descriptors it has opened. When a new packet is captured, it reads the list of active TCP connections and matches the corresponding one with the list of file descriptors.”
