### PR TITLE
implements technical edits across remaining topics

### DIFF
--- a/docs/capturing.asciidoc
+++ b/docs/capturing.asciidoc
@@ -33,7 +33,7 @@ Gigabits per second using only standard hardware.
 The `af_packet` option, also known as "memory-mapped sniffing," makes use of a
 Linux-specific
 http://lxr.free-electrons.com/source/Documentation/networking/packet_mmap.txt[feature].
-This configuration could be the optimal sniffing mode for both the dedicated server and 
+This could be the optimal sniffing mode for both the dedicated server and 
 when Packetbeat is deployed on an existing application server.
 
 The way it works is that both the kernel and the user space program map the

--- a/docs/capturing.asciidoc
+++ b/docs/capturing.asciidoc
@@ -8,49 +8,49 @@ There are two main ways of deploying Packetbeat:
 * On your existing application servers.
 
 The first option has the big advantage that there is no overhead of any kind on
-your application servers. But it requires dedicated networking gear which is
+your application servers. But it requires dedicated networking gear, which is
 generally not available on cloud setups.
 
-In both cases, the sniffing (reading packets passively from the network)
-performance is very important. In the case of a dedicated server, better
-sniffing performance means less hardware required. When Packetbeat is installed 
+In both cases, the sniffing performance (reading packets passively from the network) 
+is very important. In the case of a dedicated server, better
+sniffing performance means that less hardware is required. When Packetbeat is installed 
 on an existing application server, better sniffing performance means less overhead.
 
 Currently Packetbeat has several options for traffic capturing:
 
- * `pcap` which uses the libpcap library and works on most platforms, but
+ * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.
- * `af_packet` which uses memory mapped sniffing. It is faster than libpcap
-   and doesn't require a kernel module, but it is Linux specific.
- * `pf_ring` which makes use of an ntop.org
-   http://www.ntop.org/products/pf_ring/[project]. This will get you the best
-   sniffing speed but requires a kernel module and is Linux specific.
+ * `af_packet`, which uses memory mapped sniffing. This option is faster than libpcap 
+    and doesn't require a kernel module, but it's Linux-specific.
+ * `pf_ring`, which makes use of an ntop.org
+   http://www.ntop.org/products/pf_ring/[project]. This setting provides the best 
+   sniffing speed, but it requires a kernel module, and it's Linux-specific.
 
-The `pf_ring` option is especially attractive for the case when you have
+The `pf_ring` option is a good configuration to use when you have
 dedicated servers for Packetbeat. It provides sniffing speeds in the order of
 Gigabits per second using only standard hardware.
 
-The `af_packet` option, also known as "memory mapped sniffing" makes use of a
-Linux specific
+The `af_packet` option, also known as "memory-mapped sniffing," makes use of a
+Linux-specific
 http://lxr.free-electrons.com/source/Documentation/networking/packet_mmap.txt[feature].
-This could be the optimal sniffing mode for both the dedicated server and 
+This configuration could be the optimal sniffing mode for both the dedicated server and 
 when Packetbeat is deployed on an existing application server.
 
 The way it works is that both the kernel and the user space program map the
-same memory zone and a simple circular buffer is organized in this memory zone.
-The kernel writes packets into the circular buffer and the user space program
+same memory zone, and a simple circular buffer is organized in this memory zone.
+The kernel writes packets into the circular buffer, and the user space program
 reads from it. The poll system call is used for getting a notification for the
-first packet available, but the rest of the available packets at that time can
-be simply read via memory access.
+first packet available, but the remaining available packets can be simply read 
+via memory access.
 
-This is not quite as fast as pf_ring (it works to up to 200k packets per second
-before dropping packets) but it requires no kernel modules and it's still a
+This option is not quite as fast as `pf_ring` (it works to up to 200k packets per second
+before dropping packets), but it requires no kernel modules, and it's still a
 significant improvement over libpcap.
 
 The `af_packet` sniffer can be further tuned to use more memory in exchange for
 better performance. The larger the size of the circular buffer, the fewer
-system calls are needed, which means less CPU cycles consumed. The default size
-of the buffer is 30 MB, you can increase it like this:
+system calls are needed, which means that fewer CPU cycles are consumed. The default size
+of the buffer is 30 MB, but you can increase it like this:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -60,5 +60,5 @@ interfaces:
   buffer_size_mb: 100
 ------------------------------------------------------------------------------
 
-Please see the <<configuration-interfaces>> section for more relevant
+Please see the <<configuration-interfaces>> section for more 
 configuration options.

--- a/docs/command-line.asciidoc
+++ b/docs/command-line.asciidoc
@@ -1,5 +1,7 @@
 == Command Line Options
 
+The following command line options are available for Packetbeat. 
+
 [source,shell]
 ------------------------------------------------------------------------
 $ ./packetbeat -h
@@ -30,36 +32,36 @@ Usage of ./packetbeat:
   -version
     	Print version and exit
   -waitstop int
-    	Additional seconds to wait befor shutting down
+    	Additional seconds to wait before shutting down
 ----------------------------------------------------------------------------
 
-=== Packetbeat specific Options 
+=== Packetbeat-Specific Options 
 
-==== -I
-Instead of reading packets from the network, you can pass a `PCAP` file as input to Packetbeat. 
+These command line options are specific to Packetbeat. For other options, see {libbeat}/command-line-options.html[Beats Command Line Options].
+
+*-I <file>*::
+Pass a `PCAP` file as input to Packetbeat instead of reading packets from the network. 
 This option is useful only for testing Packetbeat. Example: `-I ~/pcaps/network_traffic.pcap`.
 
-==== -O
-Read a packet one by one by pressing _Enter_ after each. This option is useful only for testing Packetbeat.
+*-O*::
+Read packets one by one by pressing _Enter_ after each. This option is useful only for testing Packetbeat.
 
-==== -devices
-Print the list of devices. 
+*-devices*::
+Print the list of devices that are available for sniffing.
 
-==== -dump
+*-dump <file>*::
 Write all captured packets to a file. This option is useful for troubleshooting Packetbeat.
 
-==== -l
-This option needs to be used in combination with the _pcap file input (-I)_ in order to define how many times to read
-the pcap file. For a infinite loop, use _0_. This option is useful only for testing Packetbeat.
+*-l <n>*::
+Read the pcap file n number of times. Use this option in combination with _pcap file input (-I)_. 
+For an infinite loop, use _0_. This option is useful only for testing Packetbeat.
 
-==== -t
-This option needs to be used in combination with the _pcap file input (-I)_. If present, reads the packets from the pcap
-file as fast as possible, without sleeping. This option is useful only for testing Packetbeat.
+*-t*::
+Read the packets from the pcap file as fast as possible without sleeping. Use this option 
+in combination with _pcap file input (-I)_. This option is useful only for testing Packetbeat.
 
-==== -waitstop
-Additional seconds to wait before exiting.
+*-waitstop <n>*::
+Wait an additional n seconds before exiting.
 
-
-For the other options, check {libbeat}/command-line-options.html[Beats Command Line Options].
 
 

--- a/docs/command-line.asciidoc
+++ b/docs/command-line.asciidoc
@@ -37,31 +37,30 @@ Usage of ./packetbeat:
 
 === Packetbeat-Specific Options 
 
-These command line options are specific to Packetbeat. For other options, see {libbeat}/command-line-options.html[Beats Command Line Options].
+These command line options are specific to Packetbeat. For command line options common to all Beats, see {libbeat}/command-line-options.html[Beats Command Line Options].
 
-*-I <file>*::
-Pass a `PCAP` file as input to Packetbeat instead of reading packets from the network. 
+*`-I <file>`*::
+Pass a pcap file as input to Packetbeat instead of reading packets from the network. 
 This option is useful only for testing Packetbeat. Example: `-I ~/pcaps/network_traffic.pcap`.
 
-*-O*::
+*`-O`*::
 Read packets one by one by pressing _Enter_ after each. This option is useful only for testing Packetbeat.
 
-*-devices*::
+*`-devices`*::
 Print the list of devices that are available for sniffing.
 
-*-dump <file>*::
+*`-dump <file>`*::
 Write all captured packets to a file. This option is useful for troubleshooting Packetbeat.
 
-*-l <n>*::
-Read the pcap file n number of times. Use this option in combination with _pcap file input (-I)_. 
-For an infinite loop, use _0_. This option is useful only for testing Packetbeat.
+*`-l <n>`*::
+Read the pcap file `n` number of times. Use this option in combination with the `-I` option. 
+For an infinite loop, use _0_. The `-l` option is useful only for testing Packetbeat.
 
-*-t*::
-Read the packets from the pcap file as fast as possible without sleeping. Use this option 
-in combination with _pcap file input (-I)_. This option is useful only for testing Packetbeat.
+*`-t`*::
+Read the packets from the pcap file as fast as possible without sleeping. Use this option in combination with the `-I` option. The `-t` option is useful only for testing Packetbeat.
 
-*-waitstop <n>*::
-Wait an additional n seconds before exiting.
+*`-waitstop <n>`*::
+Wait an additional `n` seconds before exiting.
 
 
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -26,7 +26,7 @@ following categories:
 [[exported-fields-event]]
 === Event Fields
 
-These fields contained data about the transaction itself.
+These fields contain data about the transaction itself.
 
 
 
@@ -47,7 +47,7 @@ The timestamp of the event, as measured either by the Beat or by a common collec
 
 required: True
 
-The type of the transaction (e.g. HTTP, MySQL, Redis, RUM)
+The type of the transaction (for example, HTTP, MySQL, Redis, or RUM).
 
 
 ==== count
@@ -56,7 +56,7 @@ type: int
 
 required: True
 
-For how many transactions is this event representative. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values.
+A count of the number of transactions that this event represents. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values.
 
 
 ==== direction
@@ -70,31 +70,31 @@ Indicates whether the transaction is inbound (emitted by server) or outbound (em
 
 required: True
 
-High level status of the transaction. The way to compute this value depends on the protocol, but the result has a meaning independent a meaning independent of the protocol.
+The high level status of the transaction. The way to compute this value depends on the protocol, but the result has a meaning independent of the protocol.
 
 
 ==== method
 
-The command/verb/method of the transaction. For HTTP, this is the method name (GET, POST, PUT, etc.), for SQL this is the verb (SELECT, UPDATE, DELETE, etc.).
+The command/verb/method of the transaction. For HTTP, this is the method name (GET, POST, PUT, and so on), for SQL this is the verb (SELECT, UPDATE, DELETE, and so on).
 
 
 ==== resource
 
-The logical resource that this transaction refers to. For HTTP, this is the URL path up to the last /. For example, if the URL is `/users/1`, the resource is `/users`. For databases, the resource is typically the table name. The field is not filled for all transaction types.
+The logical resource that this transaction refers to. For HTTP, this is the URL path up to the last slash (/). For example, if the URL is `/users/1`, the resource is `/users`. For databases, the resource is typically the table name. The field is not filled for all transaction types.
 
 
 ==== path
 
 required: True
 
-The path to which the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key.
+The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key.
 
 
 ==== query
 
 type: string
 
-The query in a human readable form. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`.
+The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`.
 
 
 ==== params
@@ -104,68 +104,68 @@ The request parameters. For HTTP, these are the POST or GET parameters. For Thri
 
 ==== notes
 
-Messages from Packetbeat itself. This usually contains error messages for interpreting the raw data which can be helpful for troubleshooting.
+Messages from Packetbeat itself. This field usually contains error messages for interpreting the raw data. This information can be helpful for troubleshooting.
 
 
 [[exported-fields-dns]]
 === DNS Fields
 
-DNS specific event fields.
+DNS-specific event fields.
 
 
 ==== dns.id
 
 type: int
 
-DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
+The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
 
 
 ==== dns.op_code
 
 example: QUERY
 
-DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
+The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
 
 
 ==== dns.flags.authoritative
 
 type: bool
 
-DNS flag specifying that the responding server is an authority for the domain name used in the question.
+A DNS flag specifying that the responding server is an authority for the domain name used in the question.
 
 
 ==== dns.flags.recursion_allowed
 
 type: bool
 
-DNS flag specifying if recursive query support is available in the name server.
+A DNS flag specifying whether recursive query support is available in the name server.
 
 
 ==== dns.flags.recursion_desired
 
 type: bool
 
-DNS flag specifying that the client directs the server to pursue a query recursively. Recursive query support is optional.
+A DNS flag specifying that the client directs the server to pursue a query recursively. Recursive query support is optional.
 
 
 ==== dns.flags.truncated_response
 
 type: bool
 
-DNS flag specifying that only the first 512 bytes of the reply were returned.
+A DNS flag specifying that only the first 512 bytes of the reply were returned.
 
 
 ==== dns.response_code
 
 example: NOERROR
 
-DNS status code.
+The DNS status code.
 
 ==== dns.question.name
 
 example: www.google.com
 
-The domain name being queried. If the name field contains non-printable characters (below 32 or above 126) then those characters are represented as escaped base 10 integers (\DDD). Back slashes and quotes are escaped. Tabs, carriage returns, and line feeds will be converted to \t, \r, and \n respectively.
+The domain name being queried. If the name field contains non-printable characters (below 32 or above 126), then those characters are represented as escaped base 10 integers (\DDD). Back slashes and quotes are escaped. Tabs, carriage returns, and line feeds are converted to \t, \r, and \n respectively.
 
 
 ==== dns.question.type
@@ -184,32 +184,32 @@ The class of of records being queried.
 
 type: int
 
-The number of resource records contained in the dns.answers field.
+The number of resource records contained in the `dns.answers` field.
 
 
 ==== dns.answers.name
 
 example: example.com
 
-Domain name to which this resource record pertains.
+The domain name to which this resource record pertains.
 
 ==== dns.answers.type
 
 example: MX
 
-Type of data contained in this resource record.
+The type of data contained in this resource record.
 
 ==== dns.answers.class
 
 example: IN
 
-Class of DNS data contained in this resource record.
+The class of DNS data contained in this resource record.
 
 ==== dns.answers.ttl
 
 type: int
 
-Time interval in seconds that this resource record may be cached becore it should be discarded. Zero values mean that the data not be cached.
+The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
 ==== dns.answers.data
@@ -228,26 +228,26 @@ An array containing a dictionary for each authority section from the answer.
 
 type: int
 
-The number of resource records contained in the dns.authorities field. The dns.authorities field may or may not be included depending on the configuration of Packetbeat.
+The number of resource records contained in the `dns.authorities` field. The `dns.authorities` field may or may not be included depending on the configuration of Packetbeat.
 
 
 ==== dns.authorities.name
 
 example: example.com
 
-Domain name to which this resource record pertains.
+The domain name to which this resource record pertains.
 
 ==== dns.authorities.type
 
 example: NS
 
-Type of data contained in this resource record.
+The type of data contained in this resource record.
 
 ==== dns.authorities.class
 
 example: IN
 
-Class of DNS data contained in this resource record.
+The class of DNS data contained in this resource record.
 
 ==== dns.answers
 
@@ -260,7 +260,7 @@ An array containing a dictionary about each answer section returned by the serve
 
 type: int
 
-Time interval in seconds that this resource record may be cached becore it should be discarded. Zero values mean that the data not be cached.
+The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
 ==== dns.answers.data
@@ -279,32 +279,32 @@ An array containing a dictionary for each additional section from the answer.
 
 type: int
 
-The number of resource records contained in the dns.additionals field. The dns.additionals field may or may not be included depending on the configuration of Packetbeat.
+The number of resource records contained in the `dns.additionals` field. The `dns.additionals` field may or may not be included depending on the configuration of Packetbeat.
 
 
 ==== dns.additionals.name
 
 example: example.com
 
-Domain name to which this resource record pertains.
+The domain name to which this resource record pertains.
 
 ==== dns.additionals.type
 
 example: NS
 
-Type of data contained in this resource record.
+The type of data contained in this resource record.
 
 ==== dns.additionals.class
 
 example: IN
 
-Class of DNS data contained in this resource record.
+The class of DNS data contained in this resource record.
 
 ==== dns.additionals.ttl
 
 type: int
 
-Time interval in seconds that this resource record may be cached becore it should be discarded. Zero values mean that the data not be cached.
+The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
 ==== dns.additionals.data
@@ -315,33 +315,33 @@ The data describing the resource. The meaning of this data depends on the type a
 [[exported-fields-http]]
 === Http Fields
 
-HTTP specific event fields.
+HTTP-specific event fields.
 
 
 ==== http.code
 
 example: 404
 
-HTTP status code.
+The HTTP status code.
 
 ==== http.phrase
 
 example: Not found.
 
-HTTP status phrase.
+The HTTP status phrase.
 
 ==== http.request_headers
 
 type: dict
 
-A map containing the captured header fields from the request. Which headers to capture is configurable. If more headers with the same header name are present in the message, they will be separated by commas.
+A map containing the captured header fields from the request.  Which headers to capture is configurable. If headers with the same header name are present in the message, they will be separated by commas.
 
 
 ==== http.response_headers
 
 type: dict
 
-A map containing the captured header fields from the response. Which headers to capture is configurable. If more headers with the same header name are present in the message, they will be separated by commas.
+A map containing the captured header fields from the response.  Which headers to capture is configurable. If headers with the same header name are present in the message, they will be separated by commas.
 
 
 ==== http.content_length
@@ -354,21 +354,21 @@ The value of the Content-Length header if present.
 [[exported-fields-memcache]]
 === Memcache Fields
 
-Memcached specific event fields
+Memcached-specific event fields
 
 
 ==== memcache.protocol_type
 
 type: string
 
-Memcache protocol implementation. One of "binary", "text" or "unknown" for binary based, text based or unknown memcache protocol type.
+The memcache protocol implementation. The value can be "binary"  for binary-based, "text" for text-based, or "unknown" for an unknown  memcache protocol type.
 
 
 ==== memcache.request.line
 
 type: string
 
-Raw command line for unknown commands ONLY.
+The raw command line for unknown commands ONLY.
 
 
 ==== memcache.request.command
@@ -382,42 +382,42 @@ The memcache command being requested in the memcache text protocol. For example 
 
 type: string
 
-Either the text based protocol response message type or the name the originating request if binary protocol is used.
+Either the text based protocol response message type or the name of the originating request if binary protocol is used.
 
 
 ==== memcache.request.type
 
 type: string
 
-The memcache command classification. One of "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail" or "Auth".
+The memcache command classification. This value can be "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail", or "Auth".
 
 
 ==== memcache.response.type
 
 type: string
 
-The memcache command classification. One of "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail" or "Auth". The text based protocol will employ any any of these, whereas the binary based protocol will mirror the request commands only (see memcache.response.status for binary protocol).
+The memcache command classification. This value can be "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail", or "Auth". The text based protocol will employ any of these, whereas the binary based protocol will mirror the request commands only (see `memcache.response.status` for binary protocol).
 
 
 ==== memcache.response.error_msg
 
 type: string
 
-Optional error message in memcache response (text based protocol only).
+The optional error message in the memcache response (text based protocol only).
 
 
 ==== memcache.request.opcode
 
 type: string
 
-The binary protocol message opcode its name.
+The binary protocol message opcode name.
 
 
 ==== memcache.response.opcode
 
 type: string
 
-The binary protocol message opcode its name.
+The binary protocol message opcode name.
 
 
 ==== memcache.request.opcode_value
@@ -452,105 +452,105 @@ The binary protocol opaque header value used for correlating request with respon
 
 type: int
 
-The vbucket index send in binary message.
+The vbucket index sent in the binary message.
 
 
 ==== memcache.response.status
 
 type: string
 
-Textual representation of response error code (binary protocol only).
+The textual representation of the response error code (binary protocol only).
 
 
 ==== memcache.response.status_code
 
 type: int
 
-Status code valued returned in response (binary protocol only).
+The status code value returned in the response (binary protocol only).
 
 
 ==== memcache.request.keys
 
 type: list
 
-List of keys send in store or load commands.
+The list of keys sent in the store or load commands.
 
 
 ==== memcache.response.keys
 
 type: list
 
-List of keys returned for load command (if present).
+The list of keys returned for the load command (if present).
 
 
 ==== memcache.request.count_values
 
 type: int
 
-Number of values found in memcache request message. If command does not send any data, this field is missing.
+The number of values found in the memcache request message. If the command does not send any data, this field is missing.
 
 
 ==== memcache.response.count_values
 
 type: int
 
-Number of values found in memcache response message. If command does not send any data, this field is missing.
+The number of values found in the memcache response message. If the command does not send any data, this field is missing.
 
 
 ==== memcache.request.values
 
 type: list
 
-List of base64 encoded values send with request (If present).
+The list of base64 encoded values sent with the request (if present).
 
 
 ==== memcache.response.values
 
 type: list
 
-List of base64 encoded values send with response (If present).
+The list of base64 encoded values sent with the response (if present).
 
 
 ==== memcache.request.bytes
 
 type: int
 
-Byte count of values being transfered.
+The byte count of the values being transfered.
 
 
 ==== memcache.response.bytes
 
 type: int
 
-Byte count of values being transfered.
+The byte count of the values being transfered.
 
 
 ==== memcache.request.delta
 
 type: int
 
-Counter increment/decrement delta value
+The counter increment/decrement delta value.
 
 
 ==== memcache.request.initial
 
 type: int
 
-Counter increment/decrement initial value parameter (binary protocol only).
+The counter increment/decrement initial value parameter (binary protocol only).
 
 
 ==== memcache.request.verbosity
 
 type: int
 
-Value of memcache "verbosity" command.
+The value of the memcache "verbosity" command.
 
 
 ==== memcache.request.raw_args
 
 type: string
 
-Text protocol raw arguments for "stats ..." and "lru crawl ..." commands.
+The text protocol raw arguments for the "stats ..." and "lru crawl ..." commands.
 
 
 ==== memcache.request.source_class
@@ -571,119 +571,119 @@ The destination class id in 'slab reassign' command.
 
 type: string
 
-The automove mode in 'slab automove' command as string. One of "standby"(=0), "slow"(=1), "aggressive"(=2) or raw value if value is unknown.
+The automove mode in the 'slab automove' command expressed as a string. This value can be "standby"(=0), "slow"(=1), "aggressive"(=2), or the raw value if the value is unknown.
 
 
 ==== memcache.request.flags
 
 type: int
 
-Memcache command flags send in request (If present).
+The memcache command flags sent in the request (if present).
 
 
 ==== memcache.response.flags
 
 type: int
 
-Memcache message flags send in response (If present).
+The memcache message flags sent in the response (if present).
 
 
 ==== memcache.request.exptime
 
 type: int
 
-The data expiry time in seconds send with memcache command (If present). If value is <30 days, the expiry time is relative to "now", else it is a absolute unix time in seconds (32bit)
+The data expiry time in seconds sent with the memcache command (if present). If the value is <30 days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit).
 
 
 ==== memcache.request.sleep_us
 
 type: int
 
-Sleep setting in us for 'lru_crawler sleep' command.
+The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
 
 ==== memcache.response.value
 
 type: int
 
-General numeric value if present. For example counter operation responses.
+The counter value returned by a counter operation.
 
 
 ==== memcache.request.noreply
 
 type: bool
 
-Set to true if noreply was set in request. The memcache.response field will be missing
+Set to true if noreply was set in the request. The `memcache.response` field will be missing.
 
 
 ==== memcache.request.quiet
 
 type: bool
 
-True if binary protocol message is to be treated as quiet message.
+Set to true if the binary protocol message is to be treated as a quiet message.
 
 
 ==== memcache.request.cas_unique
 
 type: int
 
-CAS (compare-and-swap) identifier if present.
+The CAS (compare-and-swap) identifier if present.
 
 
 ==== memcache.response.cas_unique
 
 type: int
 
-CAS (compare-and-swap) identifier to be used with CAS based updates (If present).
+The CAS (compare-and-swap) identifier to be used with CAS-based updates (if present).
 
 
 ==== memcache.response.stats
 
 type: list
 
-List of statistic values returned. Each entry is a dictionary with fields "name" and "value"
+The list of statistic values returned. Each entry is a dictionary with the  fields "name" and "value".
 
 
 ==== memcache.response.version
 
 type: string
 
-Returned memcache version string.
+The returned memcache version string.
 
 
 [[exported-fields-mysql]]
 === Mysql Fields
 
-MySQL specific event fields.
+MySQL-specific event fields.
 
 
 ==== mysql.iserror
 
 type: bool
 
-In case the MySQL query returns an error, this field is set to true.
+If the MySQL query returns an error, this field is set to true.
 
 
 ==== mysql.affected_rows
 
 type: int
 
-In case of a successful MySQL command, it contains the affected number of rows of the last statement.
+If the MySQL command is successful, this field contains the affected number of rows of the last statement.
 
 
 ==== mysql.insert_id
 
-In case of a successful ``INSERT`` query, it contains the id of the newly inserted row.
+If the INSERT query is successful, this field contains the id of the newly inserted row.
 
 
 ==== mysql.num_fields
 
-In case of a successful ``SELECT`` query, it is set to the number of fields returned.
+If the SELECT query is successful, this field is set to the number of fields returned.
 
 
 ==== mysql.num_rows
 
-In case of a successful ``SELECT`` query, it is set to the number of rows returned.
+If the SELECT query is successful, this field is set to the number of rows returned.
 
 
 ==== mysql.query
@@ -706,7 +706,7 @@ The error info message returned by MySQL.
 [[exported-fields-pgsql]]
 === PostgreSQL Fields
 
-PostgreSQL specific event fields.
+PostgreSQL-specific event fields.
 
 
 ==== pgsql.query
@@ -718,7 +718,7 @@ The row pgsql query as read from the transaction's request.
 
 type: bool
 
-In case the PgSQL query returns an error, this field is set to true.
+If the PgSQL query returns an error, this field is set to true.
 
 
 ==== pgsql.error_code
@@ -737,12 +737,12 @@ The PostgreSQL error severity.
 
 ==== pgsql.num_fields
 
-In case of a successful ``SELECT`` query, it is set to the number of fields returned.
+If the SELECT query if successful, this field is set to the number of fields returned.
 
 
 ==== pgsql.num_rows
 
-In case of a successful ``SELECT`` query, it is set to the number of rows returned.
+If the SELECT query if successful, this field is set to the number of rows returned.
 
 
 [[exported-fields-thrift]]
@@ -753,7 +753,7 @@ Thrift-RPC specific event fields.
 
 ==== thrift.params
 
-The RPC method call parameters in human readable format. If the IDL files are available, the parameters are using names whenever possible. Otherwise, the IDs from the message are used.
+The RPC method call parameters in a human readable format. If the IDL files are available, the parameters use names whenever possible. Otherwise, the IDs from the message are used.
 
 
 ==== thrift.service
@@ -763,45 +763,45 @@ The name of the Thrift-RPC service as defined in the IDL files.
 
 ==== thrift.return_value
 
-The value returned by the Thrift-RPC call. This is encoded in a human readable way.
+The value returned by the Thrift-RPC call. This is encoded in a human readable format.
 
 
 ==== thrift.exceptions
 
-If the call resulted in exceptions, this field contains them in a human readable form
+If the call resulted in exceptions, this field contains the exceptions in a human readable format.
 
 
 [[exported-fields-redis]]
 === Redis Fields
 
-Redis specific event fields.
+Redis-specific event fields.
 
 
 ==== redis.return_value
 
-The return value of the Redis command in human readable form.
+The return value of the Redis command in a human readable format.
 
 
 ==== redis.error
 
-If the Redis command has resulted in an error, this field contains the error message as returned by the Redis server.
+If the Redis command has resulted in an error, this field contains the error message returned by the Redis server.
 
 
 [[exported-fields-mongodb]]
 === MongoDb Fields
 
-MongoDB specific event fields. These fields mirror closely the fields for the MongoDB wire protocol. The higher level fields (e.g. `query`, `resource`) apply to MongoDB events as well.
+MongoDB-specific event fields. These fields mirror closely the fields for the MongoDB wire protocol. The higher level fields (for example, `query` and `resource`) apply to MongoDB events as well.
 
 
 
 ==== mongodb.error
 
-If the MongoDB request has resulted in an error, this field contains the error message as returned by the server.
+If the MongoDB request has resulted in an error, this field contains the error message returned by the server.
 
 
 ==== mongodb.fullCollectionName
 
-The full collection name. The full collection name is the concatenation of the database name with the collection name, using a . for the concatenation. For example, for the database foo and the collection bar, the full collection name is foo.bar.
+The full collection name. The full collection name is the concatenation of the database name with the collection name, using a dot (.) for the concatenation. For example, for the database foo and the collection bar, the full collection name is foo.bar.
 
 
 ==== mongodb.numberToSkip
@@ -822,37 +822,37 @@ The requested maximum number of documents to be returned.
 
 type: number
 
-Number of documents in the reply
+The number of documents in the reply.
 
 
 ==== mongodb.startingFrom
 
-Where in the cursor this reply is starting
+Where in the cursor this reply is starting.
 
 
 ==== mongodb.query
 
-JSON document that represents the query. The query will contain one or more elements, all of which must match for a document to be included in the result set. Possible elements include $query, $orderby, $hint, $explain, and $snapshot.
+A JSON document that represents the query. The query will contain one or more elements, all of which must match for a document to be included in the result set. Possible elements include $query, $orderby, $hint, $explain, and $snapshot.
 
 
 ==== mongodb.returnFieldsSelector
 
-JSON document that limits the fields in the returned documents. The returnFieldsSelector contains one or more elements, each of which is the name of a field that should be returned, and and the integer value 1.
+A JSON document that limits the fields in the returned documents. The returnFieldsSelector contains one or more elements, each of which is the name of a field that should be returned, and the integer value 1.
 
 
 ==== mongodb.selector
 
-BSON document that specifies the query for selection of the document to update or delete.
+A BSON document that specifies the query for selecting the document to update or delete.
 
 
 ==== mongodb.update
 
-BSON document that specifies the update to be performed. For information on specifying updates see the Update Operations documentation from the MongoDB Manual.
+A BSON document that specifies the update to be performed. For information on specifying updates, see the Update Operations documentation from the MongoDB Manual.
 
 
 ==== mongodb.cursorId
 
-Cursor identifier that came in the OP_REPLY. This must be the value that came from the database.
+The cursor identifier returned in the OP_REPLY. This must be the value that was returned from the database.
 
 
 [[exported-fields-measurements]]
@@ -866,7 +866,7 @@ These fields contain measurements related to the transaction.
 
 type: int
 
-The wall clock time it took to for the transaction to complete. The precision is in milliseconds.
+The wall clock time it took to complete the transaction. The precision is in milliseconds.
 
 
 ==== cpu_time
@@ -879,21 +879,21 @@ The CPU time it took to complete the transaction.
 
 type: int
 
-The number of bytes of the request. Note that this size is the application layer message length, without the length of IP or TCP headers.
+The number of bytes of the request. Note that this size is the application layer message length, without the length of the IP or TCP headers.
 
 
 ==== bytes_out
 
 type: int
 
-The number of bytes of the response. Note that this size is the application layer message length, without the length of IP or TCP headers.
+The number of bytes of the response. Note that this size is the application layer message length, without the length of the IP or TCP headers.
 
 
 ==== dnstime
 
 type: int
 
-The time it takes to query the name server for a given request. This is typically used for RUM (real-user-monitoring) but can also have values for server to server communication when DNS is used for service discovery. The precision is in microseconds.
+The time it takes to query the name server for a given request. This is typically used for RUM (real-user-monitoring) but can also have values for server-to-server communication when DNS is used for service discovery. The precision is in microseconds.
 
 
 ==== connecttime
@@ -914,7 +914,7 @@ The time it takes for the content to be loaded. This is typically used for RUM (
 
 type: int
 
-In RUM (real-user-monitoring), the total time it takes for the DOM to be loaded. In terms of W3 Navigation Timing API, this is the difference between `domContentLoadedEnd` and `domContentLoadedStart`.
+In RUM (real-user-monitoring), the total time it takes for the DOM to be loaded. In terms of the W3 Navigation Timing API, this is the difference between `domContentLoadedEnd` and `domContentLoadedStart`.
 
 
 [[exported-fields-env]]
@@ -968,7 +968,7 @@ The IP address of the server that initiated the transaction.
 format: Dotted notation.
 
 If the server initiating the transaction is a proxy, this field contains the original client IP address. For HTTP, for example, the IP address extracted from a configurable HTTP header, by default `X-Forwarded-For`.
-Unless this field is disabled, it always has a value and it matches the `client_ip` for non proxy clients.
+Unless this field is disabled, it always has a value, and it matches the `client_ip` for non proxy clients.
 
 
 ==== client_location
@@ -991,7 +991,7 @@ The layer 4 port of the process that initiated the transaction.
 
 example: udp
 
-Transport protocol used for the transaction. If not specified then assume tcp.
+The transport protocol used for the transaction. If not specified, then tcp is assumed.
 
 
 ==== port

--- a/docs/filtering.asciidoc
+++ b/docs/filtering.asciidoc
@@ -1,23 +1,25 @@
-== Kibana Query and Filter
+== Kibana Queries and Filters
 
-=== Kibana Query
+In Kibana, you can filter transactions either by entering a search query or by clicking on elements within a visualization. 
 
-The search field under the *Discover* page provides a way to query 
-a specific subset of the transactions from the selected time frame.
+=== Creating Queries
+
+The search field on the *Discover* page provides a way to query 
+a specific subset of transactions from the selected time frame.
 The query syntax is based on the 
 http://lucene.apache.org/core/3_5_0/queryparsersyntax.html[Lucene query syntax]. 
-It allows boolean operators, wildcards and field filtering. For example, if 
-you want to find the http redirects, you can search for
+It allows boolean operators, wildcards, and field filtering. For example, if 
+you want to find the HTTP redirects, you can search for
 `type: http AND http.code: 302`.
 
 image:./images/kibana-query-filtering.png[Kibana query]
 
-==== String Query
+==== String Queries
 
-A query may consists of one or more words or a phrase. A phrase is a
-group of words surrounded by double quotes such as "test search".
+A query may consist of one or more words or a phrase. A phrase is a
+group of words surrounded by double quotation marks, such as `"test search"`.
 
-To search for all http requests initiated by Mozilla Web browser version 5.0:
+To search for all HTTP requests initiated by Mozilla Web browser version 5.0:
 
 [source,yaml]
 ---------------
@@ -31,8 +33,8 @@ To search for all the transactions that contain the following message:
 "Cannot change the info of a user"
 ------------------------------------
 
-Note: Double quotes are mandatory here to search for the exact
-string. Without any quotes, the search would match documents containing one of the following words:"Cannot" OR "change" OR "the" OR "info" OR "a" OR "user".
+NOTE: To search for an exact string, you need to wrap the string in double quotation 
+marks. Without quotation marks, the search in the example would match any documents containing one of the following words: "Cannot" OR "change" OR "the" OR "info" OR "a" OR "user".
 
 To search for all transactions with the "chunked" encoding:
 
@@ -41,16 +43,18 @@ To search for all transactions with the "chunked" encoding:
 "Transfer-Encoding: chunked"
 -----------------------------
 
-==== Field-based Query
+==== Field-Based Queries
 
-To only view HTTP transactions:
+Kibana allows you to search specific fields.
+
+To view HTTP transactions only:
 
 [source,yaml]
 --------------------
 type: http
 -------------------
 
-To only view failed transactions:
+To view failed transactions only:
 
 [source,yaml]
 -------------------
@@ -58,17 +62,17 @@ status: Error
 -------------------
 
 
-To only view MySQL INSERT queries:
+To view MySQL INSERT queries only:
 
 [source,yaml]
 ---------------------
 mysql.method: INSERT
 ---------------------
 
-==== Regexp Query
+==== Regexp Queries
 
-Kibana supports regular expression for filters and expressions.  For example,
-to search for all http responses with json as returned value type: 
+Kibana supports regular expression for filters and expressions. For example,
+to search for all HTTP responses with JSON as the returned value type: 
 
 [source,yaml]
 -------------------------
@@ -80,31 +84,31 @@ http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-
 for more details about the syntax.
 
 
-==== Range Query
+==== Range Queries
 
-Range queries allow a field to have values between the lower and upper bound.
+Range queries allow a field to have values between the lower and upper bounds.
 The interval can include or exclude the bounds depending on the type of
-brackets used.
+brackets that you use.
 
-To search for slow transactions with a responsetime greater or equal than 10ms:
+To search for slow transactions with a response time greater than or equal to 10ms:
 
 [source,yaml]
 ------------------------
 responsetime: [10 TO *]
 ------------------------
 
-
-To search for slow transactions with a responsetime greater than 10ms:
+To search for slow transactions with a response time greater than 10ms:
 
 [source,yaml]
 -------------------------
 responsetime: {10 TO *}
 -------------------------
 
-==== Bool Query 
+==== Boolean Queries
 
-Boolean operators (AND, OR, NOT) allow combining multiple sub queries through logic operators.
-Note: Operators such as AND, OR and NOT must be CAPITALIZED. See http://lucene.apache.org/core/3_5_0/queryparsersyntax.html[Lucene query syntax] for more details about the boolean operators.
+Boolean operators (AND, OR, NOT) allow combining multiple sub-queries through logic operators.
+
+NOTE: Operators such as AND, OR, and NOT must be capitalized. See http://lucene.apache.org/core/3_5_0/queryparsersyntax.html[Lucene query syntax] for more details about the boolean operators.
 
 To search for all transactions except MySQL transactions:
 
@@ -122,21 +126,21 @@ mysql.method: SELECT AND mysql.size: [10000 TO *]
 -------------------------------------------------
 
 
-Lucene also supports parentheses to group sub queries.
+Lucene also supports parentheses to group sub-queries.
 
-To search for either INSERT or UPDATE MySQL queries with a responsetime greater or equal with 30ms:
+To search for either INSERT or UPDATE MySQL queries with a response time greater than or equal to 30ms:
 
 [source,yaml]
 ---------------------------------------------------------------------------
 (mysql.method: INSERT OR mysql.method: UPDATE) AND responsetime: [30 TO *]
 ---------------------------------------------------------------------------
 
-=== Kibana Filter
+=== Creating Filters
 
-In Kibana, the transactions can be filtered either by entering a search query or by clicking on
-the elements within the visualization. For example, to filter for all the http redirects that are coming from a specific
-IP and port, click on both green sections of `client_ip` and `client_port` fields from the transaction detail widget. To
-exclude the http redirects coming from the IP and port, use the red sections.
+In Kibana, you can also filter transactions by clicking on
+elements within a visualization. For example, to filter for all the HTTP redirects that are coming from a specific
+IP and port, click the "Filter for value" icons (highlighted in green below) for the `client_ip` and `client_port` fields in the transaction detail widget. To
+exclude the HTTP redirects coming from the IP and port, click the icons highlighted in red.
 
 image:./images/filter_from_context.png[Filter from context]
 

--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -47,6 +47,8 @@ tar xzvf packetbeat-{version}-darwin.tgz
 NOTE: We also provide 32-bit images that you can get from our 
 https://www.elastic.co/downloads/beats/packetbeat[download page].
 
+If you are using Windows, see <<windows-install>>.
+
 
 === Configuring Packetbeat
 

--- a/docs/https.asciidoc
+++ b/docs/https.asciidoc
@@ -1,6 +1,6 @@
 == Using HTTPS and Basic Authentication
 
-To secure the communication between Packetbeat and Elasticsearch, you can use HTTPS and basic authentication. Here is an
+To secure the communication between Packetbeat and Elasticsearch, you can use HTTPS and basic authentication. Here is a 
 sample configuration:
 
 [source,yaml]
@@ -14,24 +14,43 @@ elasticsearch:
 	hosts: ["packetbeat.example.com:9200"] <4>
 -----------------------------------------------
 
-<1> The username to use for authenticating to Elasticsearch
-<2> The password to use for authenticating to Elasticsearch
-<3> This enables the HTTPS protocol
+<1> The username to use for authenticating to Elasticsearch.
+<2> The password to use for authenticating to Elasticsearch.
+<3> This setting enables the HTTPS protocol.
 <4> The IP/port of the Elasticsearch nodes. 
 
 
-Elasticsearch doesn't have built in basic authentication but you can achieve it either by using a web proxy or by using
-the https://www.elastic.co/products/shield[Shield] commercial plugin.
+Elasticsearch doesn't have built in basic authentication, but you can achieve it either by using a web proxy or by using the 
+https://www.elastic.co/products/shield[Shield] commercial plugin.
 
 Packetbeat verifies the validity of the server certificates and only accepts trusted certificates. Creating a correct
 SSL/TLS infrastructure is outside the scope of this document, but a good guide to follow is the
 https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Running a Certificate Authority] appendix from
-the Shield's guide.
+the Shield guide.
 
-Packetbeat uses the list of trusted certificate authorities from the host it is running on. Please see the documentation
-for your operating system for details on how to import your own CA certificate.
+By default Packetbeat uses the list of trusted certificate authorities from the
+operating system where the Beat is running. You can configure Packetbeat to use a specific list of
+CA certificates instead of the list from the OS. Here is an example:
 
-NOTE: The TLS handshake fails in case the SSL/TLS certificates have a subject which does not match the `hosts` value,
-for any given connection. For example, if you have `hosts: ["foobar:9200"]`, then the certificate MUST include
-`CN=foobar` in the subject or subject-alternative. Make sure the hostname resolves to the desired IP address. If no DNS
-is available, then you can just associate the right IP address with your hostname in `/etc/hosts` (on Unix systems).
+[source,yaml]
+----
+elasticsearch:
+  enabled: true
+  username: packetbeat
+  password: verysecret
+  protocol: https
+  hosts: ["elasticsearch.example.com:9200"]
+  save_topology: true
+  certificate_authorities: <1>
+    - /etc/pki/my_root_ca.pem
+    - /etc/pki/my_other_ca.pem
+----
+<1> The list of CA certificates to trust
+
+
+NOTE: For any given connection, the SSL/TLS certificates must have a subject
+that matches the value specified for `hosts`, or the TLS handshake fails. 
+For example, if you specify `hosts: ["foobar:9200"]`, the certificate MUST  
+include `foobar` in the subject (`CN=foobar`) or as a subject alternative name 
+(SAN). Make sure the hostname resolves to the correct IP address. If no DNS is available, then you can associate the IP address with your hostname in `/etc/hosts`
+(on Unix systems).

--- a/docs/kibana3.asciidoc
+++ b/docs/kibana3.asciidoc
@@ -1,20 +1,18 @@
-== Topology Diagram
+== Viewing the Topology Diagram
 
-We currently recommend using Kibana 4 together with Packetbeat. However, there
-is one panel type that is not yet available for Kibana 4, namely the topology
-diagram. This panel type is implemented in a fork of Kibana 3 that was never merged
-(and never will be). When Kibana 4 will support plugins, the panel will be
+We currently recommend using Kibana 4 together with Packetbeat. However, the topology panel type is not yet available for Kibana 4. This panel type is implemented in a fork of Kibana 3 that was never merged
+(and never will be). When Kibana 4 adds support for plugins, the topology panel will be
 re-implemented as a plugin.
 
 image:./images/topology_map.png[Topology map]
 
 This page walks you through the steps required to install the forked Kibana 3
-version and load the Packetbeat dashboards for it. You can install it side by
-side with Kibana 4.
+and load the Packetbeat dashboards. You can install Kibana 3 on the same system
+as Kibana 4.
 
-=== Download the Kibana 3 Fork
+=== Downloading the Kibana 3 Fork
 
-Download the forked Kibana like this:
+Download and install the Kibana 3 fork by issuing the following commands:
 
 [source,shell]
 ----------------------------------------------------------------------
@@ -22,11 +20,10 @@ curl -L -O https://github.com/packetbeat/kibana/releases/download/v3.1.2-pb/kiba
 tar -xzvf kibana-3.1.2-packetbeat.tar.gz
 ----------------------------------------------------------------------
 
-
 Kibana 3 is a pure Javascript application running fully in the browser. It
-doesn't have or need a sever side part like most web applications do. Instead,
+doesn't have or need a sever-side part like most web applications. Instead,
 you only needed a web server to serve the Javascript files and the static
-resources. For example, you can use python to create a simple web server:
+resources. For example, you can use Python to create a simple web server:
 
 [source,shell]
 ----------------------------------------------------------------------
@@ -34,17 +31,17 @@ cd kibana-3.1.2-packetbeat
 python -m SimpleHTTPServer
 ----------------------------------------------------------------------
 
-Now point your browser to port 8000 and you should see the Kibana web
+Now point your browser to port 8000, and you should see the Kibana web
 interface. It will probably complain that it cannot reach Elasticsearch, like
 in the following screenshot:
 
 image:./images/kibana_connection_failed.png[Kibana connection failed]
 
 This is because 
-http://en.wikipedia.org/wiki/Cross-origin_resource_sharing[CORS] is
-disabled by default in recent versions of Elasticsearch, to respect the "secure
-by default" philosophy. You can enable it by adding the following lines at the
-end of your `/etc/elasticsearch/elasticsearch.yml` file:
+http://en.wikipedia.org/wiki/Cross-origin_resource_sharing[cross-origin resource sharing (CORS)] is
+disabled by default in recent versions of Elasticsearch to respect the "secure
+by default" philosophy. You can enable CORS by adding the following lines to the
+end of the `/etc/elasticsearch/elasticsearch.yml` file:
 
 [source,yaml]
 ----------------------------------------------------------------------
@@ -52,8 +49,7 @@ http.cors.enabled: true
 http.cors.allow-origin: http://localhost:8000
 ----------------------------------------------------------------------
 
-
-Make sure to replace `http://localhost:8000` with the URL under which you
+Make sure that you replace `http://localhost:8000` with the URL under which you
 access Kibana up to the first slash. Restart Elasticsearch:
 
 [source,shell]
@@ -62,11 +58,11 @@ sudo /etc/init.d/elasticsearch restart
 ----------------------------------------------------------------------
 
 And try again to access Kibana in your browser. You should now see
-Kibana's welcoming page.
+Kibana's welcome page.
 
-=== Load Packetbeat Dashboards
+=== Loading Packetbeat Dashboards
 
-To load our sample Kibana 3 dashboards, follow these steps:
+To load our sample Kibana 3 dashboards, use the following commands:
 
 [source,shell]
 ----------------------------------------------------------------------
@@ -76,5 +72,5 @@ cd packetbeat-dashboards-k3-1.0.0~Beta1/
 ./load.sh localhost
 ----------------------------------------------------------------------
 
-In which you should replace `localhost` with the host of your Elasticsearch
+Make sure you replace `localhost` with the host of your Elasticsearch
 server.

--- a/docs/new_protocol.asciidoc
+++ b/docs/new_protocol.asciidoc
@@ -5,23 +5,18 @@ Packetbeat.
 
 === Getting Ready
 
-Packetbeat is written in http://golang.org/[Go], so having it installed and
-knowing its basics is a prerequisite for adding a new protocol. However, don't
-worry if you are not yet a Go expert, it is a sufficiently new language that
-very few people can consider themselves experts. In fact, several people learned
-Go by contributing to Packetbeat, including the original authors.
+Packetbeat is written in http://golang.org/[Go], so having Go installed and knowing the basics are prerequisites for understanding this guide. But don't worry if you aren't a Go expert. Go is a relatively new language, and very few people are experts in it. In fact, several people learned Go by contributing to Packetbeat and libbeat, including the original Packetbeat authors.
 
 You will also need a good understanding of the wire protocol that you want to
 add support for. For standard protocols or protocols used in open source
-projects you can usually find detailed specifications and example source code.
+projects, you can usually find detailed specifications and example source code.
 Wireshark is a very useful tool for understanding the inner workings of the
 protocols it supports.
 
 In some cases you can even make use of existing libraries for doing the actual
-parsing/decoding of the protocol. If the particular protocol has a Go
-implementation with a liberal enough license and that can be used to
-parse/decode individual messages, it's worth trying to use it instead of writing
-your own parser.
+parsing and decoding of the protocol. If the particular protocol has a Go
+implementation with a liberal enough license, you might be able to use it to 
+parse and decode individual messages instead of writing your own parser.
 
 Before starting, please also read the
 https://github.com/elastic/packetbeat/blob/master/CONTRIBUTING.md[CONTRIBUTING]
@@ -29,9 +24,9 @@ file on Github.
 
 ==== Cloning and Compiling
 
-After having https://golang.org/doc/install[installed Go] and having setup the
+After you have https://golang.org/doc/install[installed Go] and set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, you can clone and compile Packetbeat with the
+your preferred workspace location, you can clone Packetbeat with the
 following commands:
 
 [source,shell]
@@ -41,7 +36,7 @@ $ cd $GOPATH/src/github.com/elastic
 $ git clone https://github.com/elastic/packetbeat.git
 ----------------------------------------------------------------------
 
-and then compile it with:
+Then you can compile it with:
 
 [source,shell]
 ----------------------------------------------------------------------
@@ -51,7 +46,7 @@ $ make
 
 Note that the location where you clone is important. If you prefer working
 outside of the `GOPATH` environment, you can clone to another directory and only
-create a symlink it to the `$GOPATH/src/github.com/elastic/` directory.
+create a symlink to the `$GOPATH/src/github.com/elastic/` directory.
 
 ==== Forking and Branching
 
@@ -82,8 +77,8 @@ $ git push --set-upstream tsg cool_new_protocol
 ----------------------------------------------------------------------
 
 * When you are ready to submit your PR, simply do so from the GitHub web
-  interface. Feel free to submit your PR early, you can still add commits to
-  the branch after creating the PR. Submitting it early gives us more time to
+  interface. Feel free to submit your PR early. You can still add commits to
+  the branch after creating the PR. Submitting the PR early gives us more time to
   provide feedback and perhaps help you with it.
 
 ==== A Note About Dependencies
@@ -153,7 +148,7 @@ type UdpProtocolPlugin interface {
 }
 ----------------------------------------------------------------------
 
-At the high level, the protocols plugins receive raw packet data via the
+At a high level, the protocols plugins receive raw packet data via the
 `Parse()` or `ParseUdp()` methods and produce objects that will be indexed into
 Elasticsearch via the `results` channel.
 
@@ -174,24 +169,24 @@ type Packet struct {
 <1> The timestamp of the packet
 <2> The source IP address, source port, destination IP address, destination port
 combination.
-<3> The application layer payload (i.e. without the IP and TCP/UDP headers) as a
+<3> The application layer payload (that is, without the IP and TCP/UDP headers) as a
 byte slice.
 
-The objects sent through the `results` channel have the type `common.MapStr`
+The objects sent through the `results` channel have the type `common.MapStr`, 
 which is essentially a `map[string]interface{}` with a few more convenience
 https://github.com/elastic/libbeat/blob/fae9cf861b58f09cf578245e45415899f4151d32/common/mapstr.go[methods]
 added.
 
-Besides the `Parse()` function, the TCP layer also calls the `ReceivedFin()`
-when a TCP stream is closed and the `GapInStream()` functions when packet loss
-is detected in a TCP stream. The protocol module can use these callbacks to take
-decisions about what to do with partial data received. For example, for the
+Besides the `Parse()` function, the TCP layer also calls the `ReceivedFin()` function
+when a TCP stream is closed, and it calls the `GapInStream()` function when packet 
+loss is detected in a TCP stream. The protocol module can use these callbacks to make
+decisions about what to do with partial data that it receives. For example, for the
 HTTP/1.0 protocol, the end of connection is used to know when the message is
 finished.
 
 ==== Registering Your Plugin
 
-To Configure your plugin you have to add a configuration struct to 
+To Configure your plugin, you need to add a configuration struct to 
 `config/config.go` Protocols struct. This struct will be filled by
 https://gopkg.in/yaml.v2[goyaml] on startup.
 
@@ -240,8 +235,7 @@ var ProtocolNames = []string{
 }
 ----------------------------------------------------------------------
 
-Protocol names order must match the protocol IDs. Additionally the protocol name 
-must match the configuration name.
+The protocol names must be in the same order as their corresponding protocol IDs. Additionally the protocol name must match the configuration name.
 
 Finally register your new protocol plugin in `packetbeat.go` EnabledProtocolPlugins:
 
@@ -261,29 +255,28 @@ var EnabledProtocolPlugins map[protos.Protocol]protos.ProtocolPlugin = map[proto
 
 ----------------------------------------------------------------------
 
-Once the module is registered it can be configured and packets will be processed.
+Once the module is registered, it can be configured, and packets will be processed.
 
 Before implementing all the logic for your new protocol module, it can be
-helpful to first register it and implement the minimal plugin interface printing
-a debug message on received packets. This way you can test plugin registration
-working correctly.
+helpful to first register the module and implement the minimal plugin interface 
+for printing a debug message on received packets. This way you can test the plugin registration to ensure that it's working correctly.
 
 ==== The TCP Parse Function
 
 For TCP protocols, the `Parse()` function is the heart of the module. As
-mentioned before, it is called for every TCP packet containing data on the
-configured ports.
+mentioned earlier, this function is called for every TCP packet 
+that contains data on the configured ports.
 
-It is important to understand that because TCP is a stream
-based protocol, the packets boundaries don't necessarily match the application
+It is important to understand that because TCP is a stream-based protocol, 
+the packet boundaries don't necessarily match the application
 layer message boundaries. For example, a packet can contain only a part of the
-message, it can contain a complete message or it can contain multiple messages.
+message, it can contain a complete message, or it can contain multiple messages.
 
-If you see a packet in the middle of the stream, you have no guaranties that its
+If you see a packet in the middle of the stream, you have no guaranties that it's
 first byte is the beginning of a message. However, if the packet is the first
-seen in a given TCP stream, that you can assume is the beginning of the message.
+seen in a given TCP stream, then you can assume it is the beginning of the message.
 
-The Parse function needs to deal with these facts which generally means that it
+The `Parse()` function needs to deal with these facts, which generally means that it
 needs to keep state across multiple packets.
 
 Let's have a look again at its signature:
@@ -294,26 +287,26 @@ func Parse(pkt *protos.Packet, tcptuple *common.TcpTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData
 ----------------------------------------------------------------------
 
-We've already talked about the first parameter which contains the packet data.
+We've already talked about the first parameter, which contains the packet data.
 The rest of the parameters and the return value are used for maintaining state
 inside the TCP stream.
 
-The `tcptuple` is an unique identifier for the TCP stream from which the packet
-is part of. You can use the `tcptuple.Hashable()` functions to get a value that
+The `tcptuple` is a unique identifier for the TCP stream that the packet
+is part of. You can use the `tcptuple.Hashable()` function to get a value that
 you can store in a map. The `dir` flag gives you the direction in which the
 packet is flowing inside the TCP stream. The two possible values are
 `TcpDirectionOriginal` if the packet goes in the same direction as the first
-packet that we saw from that stream and `TcpDirectionReverse` if the packet goes
+packet from the stream and `TcpDirectionReverse` if the packet goes in 
 the other direction.
 
-The `private` parameter can be used by the module to store in the TCP stream
-whatever state it needs. The module would typically cast this at runtime to a
-type of its choice, modify it as needed and then return the modified value.
-Next time the TCP layer calls the `Parse()` or the others functions from the
-`TcpProtocolPlugin` interface, it will call it with the modified private value.
+The `private` parameter can be used by the module to store state in the TCP stream. 
+The module would typically cast this at runtime to a
+type of its choice, modify it as needed, and then return the modified value.
+The next time the TCP layer calls `Parse()` or another function from the
+`TcpProtocolPlugin` interface, it will call the function with the modified 
+private value.
 
-Here is an example handling of the private data as it's done by the MySQL
-module:
+Here is an example of how the MySQL module handles the private data:
 
 [source,go]
 ----------------------------------------------------------------------
@@ -331,8 +324,8 @@ module:
 	return priv
 ----------------------------------------------------------------------
 
-Most modules then use a logic like this to deal with incomplete data (example
-again from MySQL):
+Most modules then use a logic similar to the following to deal with incomplete 
+data (this example is also from MySQL):
 
 
 [source,go]
@@ -355,9 +348,9 @@ again from MySQL):
 ----------------------------------------------------------------------
 
 The `mysqlMessageParser()` is the function that tries to parse a single MySQL
-message. Its implementation is MySQL specific so not interesting to us for this
-guide. It returns two values: `ok` which is `false` if there was a parsing error
-from which we cannot recover and `complete` which indicates whether a complete
+message. Its implementation is MySQL-specific, so it's not interesting to us for this
+guide. It returns two values: `ok`, which is `false` if there was a parsing error
+from which we cannot recover, and `complete`, which indicates whether a complete
 and valid message was separated from the stream. These two values are used for
 deciding what to do next. In case of errors, we drop the stream. If there are no
 errors, but the message is not yet complete, we do nothing and wait for more
@@ -381,23 +374,23 @@ Packetbeat indexes into Elasticsearch a document for each request-response pair
 (called a transaction). This way we can have data from the request and the
 response in the same document and measure the response time.
 
-But this can be different for your protocol, for example for an asynchronous
+But this can be different for your protocol. For example for an asynchronous
 protocol like AMPQ, it makes more sense to index a document for every message,
-and then no correlation is necessary. On the other hand, for a session based
-protocol like SIP it might make sense to index a document for a SIP transaction
+and then no correlation is necessary. On the other hand, for a session-based
+protocol like SIP, it might make sense to index a document for a SIP transaction
 or for a full SIP dialog, which can have more than two messages.
 
 The TCP stream or UDP ports are usually good indicators that two messages belong
-to the same transactions. Therefore most protocol implementations we have in
+to the same transactions. Therefore most protocol implementations in
 Packetbeat use a map with `tcptuple` maps for correlating the requests with the
 responses. One thing you should be careful about is to expire and remove from
 this map incomplete transactions. For example, we might see the request that has
 created an entry in the map, but if we never see the reply, we need to remove
 the request from memory on a timer, otherwise we risk leaking memory.
 
-==== Send the Result
+==== Sending the Result
 
-After the correlation step, you should have an JSON like object that can be sent
+After the correlation step, you should have an JSON-like object that can be sent
 to Elasticsearch for indexing. The way you do that is by publishing it
 through the `results` publisher client, which is received by the `Init`
 function. The publisher client accepts structures of type `common.MapStr`, which
@@ -441,10 +434,10 @@ The following fields are required and their presence will be checked by
 system tests:
 
  * `@timestamp`. Set this to the timestamp of the first packet from the message
-   and cast it to `common.Time` like in the example above.
+   and cast it to `common.Time` like in the example.
  * `type`. Set this to the protocol name.
  * `count`. This is reserved for future sampling support. Set it to 1.
- * `status`. The status of the transactions, use either `common.OK_STATUS` or
+ * `status`. The status of the transactions. Use either `common.OK_STATUS` or
    `common.ERROR_STATUS`. If the protocol doesn't have responses or a meaning of
    status code, use OK.
  * `path`. This should represent what is requested, with the exact meaning
@@ -457,11 +450,11 @@ system tests:
 ===== Parsing Helpers
 
 In libbeat you also find some helpers for implementing parsers for binary and
-text based protocols. The `Bytes_*` functions being the most low level helpers
-for binary protocols using network byte order can be found in the
-`libbeat/common` module. In addition to these very low level helpers a stream
-buffer for parsing TCP based streams, or simply UDP packets with integrated
-error handling is provided by `libbeat/common/streambuf`. This demonstrates its
+text-based protocols. The `Bytes_*` functions are the most low level helpers
+for binary protocols that use network byte order. These functions can be found in the
+`libbeat/common` module. In addition to these very low level helpers, a stream
+buffer for parsing TCP-based streams, or simply UDP packets with integrated
+error handling, is provided by `libbeat/common/streambuf`. This demonstrates its
 usage for parsing the Memcache protocol UDP header:
 
 [source,go]
@@ -476,7 +469,7 @@ func parseUdpHeader(buf *streambuf.Buffer) (mcUdpHeader, error) {
 }
 ----------------------------------------------------------------------
 
-The stream buffer is also used to implement the binary and text based protocols
+The stream buffer is also used to implement the binary and text-based protocols
 for memcache.
 
 [source,go]
@@ -530,7 +523,7 @@ for memcache.
 	}
 ----------------------------------------------------------------------
 
-It also implements a number of interfaces defined in the standard "io" package
+The stream buffer also implements a number of interfaces defined in the standard "io" package
 and can easily be used to serialize some packets for testing parsers (see
 `protos/memcache/binary_test.go`).
 
@@ -538,9 +531,8 @@ and can easily be used to serialize some packets for testing parsers (see
 
 Packetbeat provides the module `packetbeat/protos/applayer` with
 common definitions among all application layer protocols. For example using the
-Transaction type from `applayer` guarantees the final document to have all common
-required fields defined. Just embed the `applayer.Transaction` with your own
-application layer transaction type to make use of it (from memcache protocol):
+Transaction type from `applayer` guarantees that the final document will have all common required fields defined. Just embed the `applayer.Transaction` with your own
+application layer transaction type to make use of it. Here is an example from the memcache protocol:
 
 [source,go]
 ----------------------------------------------------------------------
@@ -581,14 +573,13 @@ http://golang.org/pkg/testing/[testing] package. To make comparing complex
 structures less verbose, we use the assert package from the
 https://github.com/stretchr/testify[testify] library.
 
-For parser/decoder tests, we find it is a good practice to have an array with
-test cases containing the inputs and expected outputs. For an example, see for
-example the
+For parser and decoder tests, we find it is a good practice to have an array with
+test cases containing the inputs and expected outputs. For an example, see the 
 https://github.com/elastic/packetbeat/blob/b9173ae034581205ed4853c6fb040ea5357a5c28/protos/http/http_test.go#L1012[`Test_splitCookiesHeaders`]
 unit test.
 
 You can also have unit tests that treat the whole module as a black box, calling
-it's interface functions then reading the result from the `results` channel and
+its interface functions, then reading the result from the `results` channel and
 checking it. This pattern is especially useful for checking corner cases related
 to packet boundaries or correlation issues. Here is an example from the HTTP
 module:
@@ -651,7 +642,7 @@ is passed from one call to the next like the TCP layer would do.
 
 <4> The
 https://github.com/elastic/packetbeat/blob/b9173ae034581205ed4853c6fb040ea5357a5c28/protos/http/http_test.go#L1182[`expectTransaction`]
-function tries to read from the `results` channel and errors the test case if
+function tries to read from the `results` channel and causes errors in the test case if
 there's no transaction present.
 
 To check the coverage of your unit tests, run the `make cover` command at the
@@ -701,7 +692,7 @@ all debug messages.
 
 <3> After the run, the test reads the output files and checks the result.
 
-Tip: to generate the PCAP files, you can use Packetbeat itself. The `-dump` CLI
+Tip: To generate the PCAP files, you can use Packetbeat. The `-dump` CLI
 flag will dump to disk all the packets sniffed from the network that match the
 BPF filter.
 
@@ -712,7 +703,7 @@ To run the whole test suite, use:
 $ make test
 ----------------------------------------------------------------------
 
-This requires you to have python and virtualenv installed, but it automatically
+This requires you to have Python and virtualenv installed, but it automatically
 creates and uses the virtualenv.
 
 To run an individual test, use the following steps:
@@ -724,9 +715,9 @@ $ . env/bin/activate
 $ nosetests test_0025_mongodb_basic.py:Test.test_write_errors
 ----------------------------------------------------------------------
 
-After running the individual test, you can check the logs, the output and
-configuration file manually by looking into the folder pointed by the `last_run`
-symlink:
+After running the individual test, you can check the logs, the output, and the
+configuration file manually by looking into the folder that the `last_run`
+symlink points to:
 
 [source,shell]
 ----------------------------------------------------------------------

--- a/docs/new_protocol.asciidoc
+++ b/docs/new_protocol.asciidoc
@@ -148,7 +148,7 @@ type UdpProtocolPlugin interface {
 }
 ----------------------------------------------------------------------
 
-At a high level, the protocols plugins receive raw packet data via the
+At the high level, the protocols plugins receive raw packet data via the
 `Parse()` or `ParseUdp()` methods and produce objects that will be indexed into
 Elasticsearch via the `results` channel.
 
@@ -186,7 +186,7 @@ finished.
 
 ==== Registering Your Plugin
 
-To Configure your plugin, you need to add a configuration struct to 
+To configure your plugin, you need to add a configuration struct to 
 `config/config.go` Protocols struct. This struct will be filled by
 https://gopkg.in/yaml.v2[goyaml] on startup.
 
@@ -450,12 +450,12 @@ system tests:
 ===== Parsing Helpers
 
 In libbeat you also find some helpers for implementing parsers for binary and
-text-based protocols. The `Bytes_*` functions are the most low level helpers
+text-based protocols. The `Bytes_*` functions are the most low-level helpers
 for binary protocols that use network byte order. These functions can be found in the
-`libbeat/common` module. In addition to these very low level helpers, a stream
+`libbeat/common` module. In addition to these very low-level helpers, a stream
 buffer for parsing TCP-based streams, or simply UDP packets with integrated
-error handling, is provided by `libbeat/common/streambuf`. This demonstrates its
-usage for parsing the Memcache protocol UDP header:
+error handling, is provided by `libbeat/common/streambuf`. The following example
+demonstrates using the stream buffer for parsing the Memcache protocol UDP header:
 
 [source,go]
 ----------------------------------------------------------------------
@@ -573,7 +573,7 @@ http://golang.org/pkg/testing/[testing] package. To make comparing complex
 structures less verbose, we use the assert package from the
 https://github.com/stretchr/testify[testify] library.
 
-For parser and decoder tests, we find it is a good practice to have an array with
+For parser and decoder tests, it's a good practice to have an array with
 test cases containing the inputs and expected outputs. For an example, see the 
 https://github.com/elastic/packetbeat/blob/b9173ae034581205ed4853c6fb040ea5357a5c28/protos/http/http_test.go#L1012[`Test_splitCookiesHeaders`]
 unit test.

--- a/docs/thrift.asciidoc
+++ b/docs/thrift.asciidoc
@@ -13,7 +13,7 @@ any way and without any latency overhead. Packetbeat captures the transactions f
 network and indexes them in Elasticsearch so that they can be analyzed and
 searched.
 
-Packetbeat indexes the method, parameters, return value, and the
+Packetbeat indexes the method, parameters, return value, and 
 exceptions of each Thrift-RPC call. You can search by and create statistics
 based on any of these fields. Packetbeat automatically fills in the `status`
 column with either `OK` or `Error`, so it's easy to find the problematic RPC calls.
@@ -22,7 +22,7 @@ A transaction is put into the `Error` state if it returned an exception.
 Packetbeat also indexes the `responsetime` field so you can get performance
 analytics and find the slow RPC calls.
 
-Here is an example a performance dashboard:
+Here is an example performance dashboard:
 
 image:./images/thrift-dashboard.png[Thrift-RPC dashboard]
 

--- a/docs/thrift.asciidoc
+++ b/docs/thrift.asciidoc
@@ -9,20 +9,20 @@ programming languages and frameworks.
 
 Packetbeat works based on a copy of the traffic, which means that you get
 performance management features without having to modify your services in
-any way and without any latency overhead. It captures the transactions from the
+any way and without any latency overhead. Packetbeat captures the transactions from the
 network and indexes them in Elasticsearch so that they can be analyzed and
 searched.
 
-Packetbeat indexes the method, the parameters, the return value and the
+Packetbeat indexes the method, parameters, return value, and the
 exceptions of each Thrift-RPC call. You can search by and create statistics
-based on any of these fields. Packetbeat fills in automatically the `status`
-column with either `OK` or `Error` so it's easy find the problematic RPC calls.
+based on any of these fields. Packetbeat automatically fills in the `status`
+column with either `OK` or `Error`, so it's easy to find the problematic RPC calls.
 A transaction is put into the `Error` state if it returned an exception.
 
-Packetbeat also indexes the  `responsetime` field so you can get performance
+Packetbeat also indexes the `responsetime` field so you can get performance
 analytics and find the slow RPC calls.
 
-Here is an example performance dashboard:
+Here is an example a performance dashboard:
 
 image:./images/thrift-dashboard.png[Thrift-RPC dashboard]
 
@@ -32,12 +32,12 @@ and protocol types]. Currently Packetbeat supports the default `TSocket`
 transport as well as the `TFramed` transport. From the protocol point of view,
 Packetbeat currently supports only the default `TBinary` protocol.
 
-Packetbeat also has several configuration options allowing you to get
-the right balance between visibility and disk usage / data protection. You can
+Packetbeat also has several configuration options that allow you to get
+the right balance between visibility, disk usage, and data protection. You can, 
 for example, choose to obfuscate all strings or to store the requests but not
 the responses, while still capturing the response time for each of the RPC
 calls. You can also choose to limit the size of strings and lists to a given
-number of elements, so you can fine tune how much you want to have stored in
+number of elements, so you can fine tune how much data you want to have stored in
 Elasticsearch.
 
 Here is an example configuration section for the Thrift protocol:
@@ -56,11 +56,11 @@ protocols:
     drop_after_n_struct_fields = 100
 ------------------------------------------------------------------------------
 
-More details about the configuration options can be found in the
+For more details about the configuration options, see the
 <<configuration-thrift>> section.
 
 Providing the Thrift IDL files to Packetbeat is optional. The binary
-Thrift messages include the called method name and enough structure information
-to decode the messages without the need of the IDL files. However, if you
-provide the IDL files, Packetbeat can also resolve the service name, the
-arguments and exceptions names.
+Thrift messages include the called method name and enough structural information
+to decode the messages without needing the IDL files. However, if you
+provide the IDL files, Packetbeat can also resolve the service name, 
+arguments, and exception names.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -3,18 +3,18 @@
 If you suspect an issue with Packetbeat, please read the
 following tips and send us the logs and, if possible, a traffic trace.
 
-Please contact us on the https://discuss.elastic.co/c/beats/packetbeat[forums].
-We will help you troubleshoot the problem you are facing.
+Please contact us on the https://discuss.elastic.co/c/beats/packetbeat[forums], and 
+we'll help you troubleshoot the problem.
 
-If you are sure you found a bug, you can also open a ticket on
+If you're sure you found a bug, you can open a ticket on
 https://github.com/elastic/packetbeat/issues?state=open[GitHub]. Note, however,
-that we close GitHub issues if they are questions or requests for help that
+that we close GitHub issues containing questions or requests for help if they
 don't indicate the presence of a bug.
 
 === Running in the Foreground and Enabling Debugging
 
 By default, Packetbeat sends all its output to syslog. You can use the `-e`
-command line flag to direct the output at standard error instead:
+command line flag to redirect the output to standard error instead:
 
 [source,shell]
 -----------------------------------------------
@@ -22,15 +22,16 @@ packetbeat -e
 -----------------------------------------------
 
 The default configuration file is `/etc/packetbeat/packetbeat.yml`. You can use
-another file by using the `-c` flag:
+a different file by using the `-c` flag:
 
 [source,shell]
 ------------------------------------------------------------
 packetbeat -e -c /etc/packetbeat/packetbeat.yml
 ------------------------------------------------------------
 
-You can increase the verbosity by enabling one or more debug selectors. For
-example, to view which transactions are published, you can start Packetbeat like
+You can increase the verbosity of debug messages by enabling one or more debug 
+selectors. For
+example, to view the published transactions, you can start Packetbeat like
 this:
 
 [source,shell]
@@ -38,7 +39,7 @@ this:
 packetbeat -e -d "publish"
 ------------------------------------------------------------
 
-You can enable multiple debug selectors by separating them with comas. For
+You can enable multiple debug selectors by separating them with commas. For
 example, if you want to also see the mysql parsing messages, run:
 
 [source,shell]
@@ -66,7 +67,7 @@ Here is the list of commonly used debug selectors:
 * thrift
 * thriftdetailed
 
-If you want all the debugging output (fair warning, it is quite a lot), you can
+If you want all the debugging output (fair warning, it's quite a lot), you can
 use `*`, like this:
 
 [source,shell]
@@ -76,23 +77,22 @@ packetbeat -e -d "*"
 
 === Recording a Trace
 
-If you are having an issue, it is often useful to record a full network trace
-and send it to us. It will help us reproduce the issue and we can also add it
+If you are having an issue, it's often useful to record a full network trace
+and send it to us. It will help us reproduce the issue, and we can also add it
 to our automatic regression tests so that the problem never reoccurs. A trace
-of 10-20 seconds is usually enough. To record it, you can use Packetbeat itself
-like this:
+of 10-20 seconds is usually enough. To record the trace, you can use the following Packetbeat command:
 
 [source,shell]
 ------------------------------------------------------------
 packetbeat -e -dump trace.pcap
 ------------------------------------------------------------
 
-This executes Packetbeat in normal mode (all processing happens as usual) but
-at the same time records all packets in libpcap format in the `trace.pcap`
+This command executes Packetbeat in normal mode (all processing happens as usual), but
+at the same time, it records all packets in libpcap format in the `trace.pcap`
 file. If there's a particular error message you want us to investigate, please
 keep the trace running until the error shows up (it will printed on standard
 error).
 
 WARNING: PCAP files can be large. Please monitor the disk usage while doing the
 dump to make sure you don't run out of disk space. Whenever possible, we
-recommend doing this on a non-production machine.
+recommend recording the trace on a non-production machine.

--- a/docs/windows.asciidoc
+++ b/docs/windows.asciidoc
@@ -1,49 +1,53 @@
-
-== Windows Support
+[[windows-install]]
+== Installing Packetbeat on Windows
 
 This page walks you through the steps required for running Packetbeat on
 Windows. It assumes your Windows system has Powershell installed.
 
-Start by downloading and installing WinPcap from this
+To install and run Packetbeat:
+
+. Download and install WinPcap from this
 http://www.winpcap.org/install/default.htm[page]. WinPcap is a library that uses
 a driver to enable packet capturing.
 
-Then download the Packetbeat Windows zip file from the
+. Download the Packetbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/packetbeat[downloads page] and unzip
-it on your computer. The location where it is extracted is not important, but
+it on your computer. The location where you extract the file is not important, but
 remember that you shouldn't delete this repository after the installation is
 finished. The exe file and the configuration file will continue to live there.
 
-Then start an Administrator Powershell session (right click the Powershell icon
-and select *Run as Administrator*), and navigate to where you uncompressed the
+. Start an Administrator Powershell session (right click the Powershell icon
+and select *Run as Administrator*), and navigate to where you extracted the
 zip file.
-
++
 Use the following command to list the available network interfaces:
-
++
 [source,shell]
 ----------------------------------------------------------------------
 PS > .\packetbeat.exe -devices
 
 0: \Device\NPF_{113535AD-934A-452E-8D5F-3004797DE286} (Intel(R) PRO/1000 MT Desktop Adapter)
 ----------------------------------------------------------------------
-
++
 In this example, there is only one network card installed on the system. If
-there are more of them, remember the index of the device you want to use for
+there are multiple network cards, remember the index of the device you want to use for
 capturing the traffic.
 
-Then edit the `packetbeat.yml` file and modify the `device` line to point to the
-index that you just found:
-
+. Edit the `packetbeat.yml` file and modify the `device` line to point to the
+index of the device:
++
 [source,yml]
 ----------------------------------------------------------------------
 interfaces:
   device: 0
 ----------------------------------------------------------------------
++
+You might want to change other settings in the `packetbeat.yml` file. See 
+ <<packetbeat-configuration>> for details.
 
-You might want to change other settings in the `packetbeat.yml` file, see the
- <<packetbeat-configuration>> documentation for details.
+=== Installing Packetbeat as a Windows Service
 
-Then you can install Packetbeat as a Windows service by using the following
+You can install Packetbeat as a Windows service by using the following
 Powershell script:
 
 [source,shell]
@@ -51,11 +55,11 @@ Powershell script:
 PS > .\install-service-packetbeat.ps1
 ----------------------------------------------------------------------
 
-And then start it with:
+To start the Packetbeat service, issue this command:
 
 [source,shell]
 ----------------------------------------------------------------------
 PS > Start-Service packetbeat
 ----------------------------------------------------------------------
 
-By default the log files can be found under `C:\ProgramData\packetbeat\Logs`.
+By default the log files are stored in `C:\ProgramData\packetbeat\Logs`.

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -50,7 +50,7 @@ env:
         For HTTP, for example, the IP address extracted from a configurable
         HTTP header, by default `X-Forwarded-For`.
 
-        Unless this field is disabled, it always has a value and it matches
+        Unless this field is disabled, it always has a value, and it matches
         the `client_ip` for non proxy clients.
       format: Dotted notation.
 
@@ -69,8 +69,8 @@ env:
 
     - name: transport
       description: >
-        Transport protocol used for the transaction. If not specified then
-        assume tcp.
+        The transport protocol used for the transaction. If not specified, then
+        tcp is assumed.
       example: udp
 
     - name: port
@@ -99,7 +99,7 @@ env:
 event:
   type: group
   description: >
-    These fields contained data about the transaction itself.
+    These fields contain data about the transaction itself.
   fields:
     - name: "@timestamp"
       type: date
@@ -113,13 +113,13 @@ event:
 
     - name: type
       description: >
-        The type of the transaction (e.g. HTTP, MySQL, Redis, RUM)
+        The type of the transaction (for example, HTTP, MySQL, Redis, or RUM).
       required: true
 
     - name: count
       type: int
       description: >
-        For how many transactions is this event representative. This
+        A count of the number of transactions that this event represents. This
         is generally the inverse of the sampling rate. For example, for
         a sample rate of 1/10, the count is 10. The count is used by the
         UIs to return estimated values.
@@ -136,9 +136,9 @@ event:
 
     - name: status
       description: >
-        High level status of the transaction. The way to compute this
+        The high level status of the transaction. The way to compute this
         value depends on the protocol, but the result has a meaning
-        independent a meaning independent of the protocol.
+        independent of the protocol.
       required: true
       possible_values:
         - OK
@@ -149,20 +149,20 @@ event:
     - name: method
       description: >
         The command/verb/method of the transaction. For HTTP, this is the
-        method name (GET, POST, PUT, etc.), for SQL this is the verb (SELECT,
-        UPDATE, DELETE, etc.).
+        method name (GET, POST, PUT, and so on), for SQL this is the verb (SELECT,
+        UPDATE, DELETE, and so on).
 
     - name: resource
       description: >
         The logical resource that this transaction refers to. For HTTP, this is
-        the URL path up to the last /. For example, if the URL is `/users/1`,
+        the URL path up to the last slash (/). For example, if the URL is `/users/1`,
         the resource is `/users`. For databases, the resource is typically the
         table name. The field is not filled for all transaction types.
 
     - name: path
       required: true
       description: >
-        The path to which the transaction refers to. For HTTP, this is the URL.
+        The path the transaction refers to. For HTTP, this is the URL.
         For SQL databases, this is the table name. For key-value stores, this
         is the key.
 
@@ -172,7 +172,7 @@ event:
       index: not_analyzed
       doc_values: true
       description: >
-        The query in a human readable form. For HTTP, it will typically be
+        The query in a human readable format. For HTTP, it will typically be
         something like `GET /users/_search?name=test`. For MySQL, it is
         something like `SELECT id from users where name=test`.
 
@@ -184,22 +184,22 @@ event:
 
     - name: notes
       description: >
-        Messages from Packetbeat itself. This usually contains error messages for
-        interpreting the raw data which can be helpful for troubleshooting.
+        Messages from Packetbeat itself. This field usually contains error messages for
+        interpreting the raw data. This information can be helpful for troubleshooting.
 
     - name: dns
       type: group
-      description: DNS specific event fields.
+      description: DNS-specific event fields.
       fields:
         - name: dns.id
           type: int
           description: >
-            DNS packet identifier assigned by the program that generated the
+            The DNS packet identifier assigned by the program that generated the
             query. The identifier is copied to the response.
 
         - name: dns.op_code
           description: >
-            DNS operation code that specifies the kind of query in the message.
+            The DNS operation code that specifies the kind of query in the message.
             This value is set by the originator of a query and copied into the
             response.
           example: QUERY
@@ -207,37 +207,37 @@ event:
         - name: dns.flags.authoritative
           type: bool
           description: >
-            DNS flag specifying that the responding server is an authority for
+            A DNS flag specifying that the responding server is an authority for
             the domain name used in the question.
 
         - name: dns.flags.recursion_allowed
           type: bool
           description: >
-            DNS flag specifying if recursive query support is available in the
+            A DNS flag specifying whether recursive query support is available in the
             name server.
 
         - name: dns.flags.recursion_desired
           type: bool
           description: >
-            DNS flag specifying that the client directs the server to pursue a
+            A DNS flag specifying that the client directs the server to pursue a
             query recursively. Recursive query support is optional.
 
         - name: dns.flags.truncated_response
           type: bool
           description: >
-            DNS flag specifying that only the first 512 bytes of the reply were
+            A DNS flag specifying that only the first 512 bytes of the reply were
             returned.
 
         - name: dns.response_code
-          description: DNS status code.
+          description: The DNS status code.
           example: NOERROR
 
         - name: dns.question.name
           description: >
             The domain name being queried. If the name field contains non-printable
-            characters (below 32 or above 126) then those characters are represented
+            characters (below 32 or above 126), then those characters are represented
             as escaped base 10 integers (\DDD). Back slashes and quotes are escaped.
-            Tabs, carriage returns, and line feeds will be converted to \t, \r, and
+            Tabs, carriage returns, and line feeds are converted to \t, \r, and
             \n respectively.
           example: www.google.com
 
@@ -252,24 +252,24 @@ event:
         - name: dns.answers_count
           type: int
           description: >
-            The number of resource records contained in the dns.answers field.
+            The number of resource records contained in the `dns.answers` field.
 
         - name: dns.answers.name
-          description: Domain name to which this resource record pertains.
+          description: The domain name to which this resource record pertains.
           example: example.com
 
         - name: dns.answers.type
-          description: Type of data contained in this resource record.
+          description: The type of data contained in this resource record.
           example: MX
 
         - name: dns.answers.class
-          description: Class of DNS data contained in this resource record.
+          description: The class of DNS data contained in this resource record.
           example: IN
 
         - name: dns.answers.ttl
           description: >
-            Time interval in seconds that this resource record may be cached
-            becore it should be discarded. Zero values mean that the data
+            The time interval in seconds that this resource record may be cached
+            before it should be discarded. Zero values mean that the data should 
             not be cached.
           type: int
 
@@ -287,20 +287,20 @@ event:
         - name: dns.authorities_count
           type: int
           description: >
-            The number of resource records contained in the dns.authorities field.
-            The dns.authorities field may or may not be included depending on the
+            The number of resource records contained in the `dns.authorities` field.
+            The `dns.authorities` field may or may not be included depending on the
             configuration of Packetbeat.
 
         - name: dns.authorities.name
-          description: Domain name to which this resource record pertains.
+          description: The domain name to which this resource record pertains.
           example: example.com
 
         - name: dns.authorities.type
-          description: Type of data contained in this resource record.
+          description: The type of data contained in this resource record.
           example: NS
 
         - name: dns.authorities.class
-          description: Class of DNS data contained in this resource record.
+          description: The class of DNS data contained in this resource record.
           example: IN
 
         - name: dns.answers
@@ -311,8 +311,8 @@ event:
 
         - name: dns.answers.ttl
           description: >
-            Time interval in seconds that this resource record may be cached
-            becore it should be discarded. Zero values mean that the data
+            The time interval in seconds that this resource record may be cached
+            before it should be discarded. Zero values mean that the data should 
             not be cached.
           type: int
 
@@ -330,26 +330,26 @@ event:
         - name: dns.additionals_count
           type: int
           description: >
-            The number of resource records contained in the dns.additionals field.
-            The dns.additionals field may or may not be included depending on the
+            The number of resource records contained in the `dns.additionals` field.
+            The `dns.additionals` field may or may not be included depending on the
             configuration of Packetbeat.
 
         - name: dns.additionals.name
-          description: Domain name to which this resource record pertains.
+          description: The domain name to which this resource record pertains.
           example: example.com
 
         - name: dns.additionals.type
-          description: Type of data contained in this resource record.
+          description: The type of data contained in this resource record.
           example: NS
 
         - name: dns.additionals.class
-          description: Class of DNS data contained in this resource record.
+          description: The class of DNS data contained in this resource record.
           example: IN
 
         - name: dns.additionals.ttl
           description: >
-            Time interval in seconds that this resource record may be cached
-            becore it should be discarded. Zero values mean that the data
+            The time interval in seconds that this resource record may be cached
+            before it should be discarded. Zero values mean that the data should 
             not be cached.
           type: int
 
@@ -360,29 +360,29 @@ event:
 
     - name: http
       type: group
-      description: HTTP specific event fields.
+      description: HTTP-specific event fields.
       fields:
         - name: http.code
-          description: HTTP status code.
+          description: The HTTP status code.
           example: 404
 
         - name: http.phrase
-          description: HTTP status phrase.
+          description: The HTTP status phrase.
           example: Not found.
 
         - name: http.request_headers
           type: dict
           description: >
-            A map containing the captured header fields from the request. Which
-            headers to capture is configurable. If more headers with the same
+            A map containing the captured header fields from the request. 
+            Which headers to capture is configurable. If headers with the same
             header name are present in the message, they will be separated by
             commas.
 
         - name: http.response_headers
           type: dict
           description: >
-            A map containing the captured header fields from the response.
-            Which headers to capture is configurable. If more headers with the
+            A map containing the captured header fields from the response. 
+            Which headers to capture is configurable. If headers with the
             same header name are present in the message, they will be separated
             by commas.
 
@@ -393,18 +393,19 @@ event:
 
     - name: memcache
       type: group
-      description: Memcached specific event fields
+      description: Memcached-specific event fields
       fields:
         - name: memcache.protocol_type
           type: string
           description: >
-            Memcache protocol implementation. One of "binary", "text" or "unknown" for
-            binary based, text based or unknown memcache protocol type.
+            The memcache protocol implementation. The value can be "binary" 
+            for binary-based, "text" for text-based, or "unknown" for an unknown 
+            memcache protocol type.
 
         - name: memcache.request.line
           type: string
           description: >
-            Raw command line for unknown commands ONLY.
+            The raw command line for unknown commands ONLY.
 
         - name: memcache.request.command
           type: string
@@ -418,39 +419,39 @@ event:
           type: string
           description: >
             Either the text based protocol response message type
-            or the name the originating request if binary protocol is used.
+            or the name of the originating request if binary protocol is used.
 
         - name: memcache.request.type
           type: string
           description: >
-            The memcache command classification. One of "UNKNOWN", "Load",
+            The memcache command classification. This value can be "UNKNOWN", "Load",
             "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler",
-            "Stats", "Success", "Fail" or "Auth".
+            "Stats", "Success", "Fail", or "Auth".
 
         - name: memcache.response.type
           type: string
           description: >
-            The memcache command classification. One of "UNKNOWN", "Load",
+            The memcache command classification. This value can be "UNKNOWN", "Load",
             "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler",
-            "Stats", "Success", "Fail" or "Auth".
-            The text based protocol will employ any any of these, whereas the
+            "Stats", "Success", "Fail", or "Auth".
+            The text based protocol will employ any of these, whereas the
             binary based protocol will mirror the request commands only (see
-            memcache.response.status for binary protocol).
+            `memcache.response.status` for binary protocol).
 
         - name: memcache.response.error_msg
           type: string
           description: >
-            Optional error message in memcache response (text based protocol only).
+            The optional error message in the memcache response (text based protocol only).
 
         - name: memcache.request.opcode
           type: string
           description: >
-            The binary protocol message opcode its name.
+            The binary protocol message opcode name.
 
         - name: memcache.response.opcode
           type: string
           description: >
-            The binary protocol message opcode its name.
+            The binary protocol message opcode name.
 
         - name: memcache.request.opcode_value
           type: int
@@ -477,80 +478,80 @@ event:
         - name: memcache.request.vbucket
           type: int
           description: >
-            The vbucket index send in binary message.
+            The vbucket index sent in the binary message.
 
         - name: memcache.response.status
           type: string
           description: >
-            Textual representation of response error code
+            The textual representation of the response error code
             (binary protocol only).
 
         - name: memcache.response.status_code
           type: int
           description: >
-            Status code valued returned in response (binary protocol only).
+            The status code value returned in the response (binary protocol only).
 
         - name: memcache.request.keys
           type: list
           description: >
-            List of keys send in store or load commands.
+            The list of keys sent in the store or load commands.
 
         - name: memcache.response.keys
           type: list
           description: >
-            List of keys returned for load command (if present).
+            The list of keys returned for the load command (if present).
 
         - name: memcache.request.count_values
           type: int
           description: >
-            Number of values found in memcache request message.
-            If command does not send any data, this field is missing.
+            The number of values found in the memcache request message.
+            If the command does not send any data, this field is missing.
 
         - name: memcache.response.count_values
           type: int
           description: >
-            Number of values found in memcache response message.
-            If command does not send any data, this field is missing.
+            The number of values found in the memcache response message.
+            If the command does not send any data, this field is missing.
 
         - name: memcache.request.values
           type: list
           description: >
-            List of base64 encoded values send with request (If present).
+            The list of base64 encoded values sent with the request (if present).
 
         - name: memcache.response.values
           type: list
           description: >
-            List of base64 encoded values send with response (If present).
+            The list of base64 encoded values sent with the response (if present).
 
         - name: memcache.request.bytes
           type: int
           description: >
-            Byte count of values being transfered.
+            The byte count of the values being transfered.
 
         - name: memcache.response.bytes
           type: int
           description: >
-            Byte count of values being transfered.
+            The byte count of the values being transfered.
 
         - name: memcache.request.delta
           type: int
           description: >
-            Counter increment/decrement delta value
+            The counter increment/decrement delta value.
 
         - name: memcache.request.initial
           type: int
           description: >
-            Counter increment/decrement initial value parameter (binary protocol only).
+            The counter increment/decrement initial value parameter (binary protocol only).
 
         - name: memcache.request.verbosity
           type: int
           description: >
-            Value of memcache "verbosity" command.
+            The value of the memcache "verbosity" command.
 
         - name: memcache.request.raw_args
           type: string
           description: >
-            Text protocol raw arguments for "stats ..." and "lru crawl ..." commands.
+            The text protocol raw arguments for the "stats ..." and "lru crawl ..." commands.
 
         - name: memcache.request.source_class
           type: int
@@ -565,99 +566,99 @@ event:
         - name: memcache.request.automove
           type: string
           description: >
-              The automove mode in 'slab automove' command as string.
-              One of "standby"(=0), "slow"(=1), "aggressive"(=2) or raw value if
-              value is unknown.
+              The automove mode in the 'slab automove' command expressed as a string.
+              This value can be "standby"(=0), "slow"(=1), "aggressive"(=2), or the raw value if
+              the value is unknown.
 
         - name: memcache.request.flags
           type: int
           description: >
-            Memcache command flags send in request (If present).
+            The memcache command flags sent in the request (if present).
 
         - name: memcache.response.flags
           type: int
           description: >
-            Memcache message flags send in response (If present).
+            The memcache message flags sent in the response (if present).
 
         - name: memcache.request.exptime
           type: int
           description: >
-            The data expiry time in seconds send with memcache command (If present).
-            If value is <30 days, the expiry time is relative to "now", else it
-            is a absolute unix time in seconds (32bit)
+            The data expiry time in seconds sent with the memcache command (if present).
+            If the value is <30 days, the expiry time is relative to "now", or else it
+            is an absolute Unix time in seconds (32-bit).
 
         - name: memcache.request.sleep_us
           type: int
           description: >
-            Sleep setting in us for 'lru_crawler sleep' command.
+            The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
         - name: memcache.response.value
           type: int
           description: >
-            General numeric value if present. For example counter operation responses.
+            The counter value returned by a counter operation.
 
         - name: memcache.request.noreply
           type: bool
           description: >
-            Set to true if noreply was set in request.
-            The memcache.response field will be missing
+            Set to true if noreply was set in the request.
+            The `memcache.response` field will be missing.
 
         - name: memcache.request.quiet
           type: bool
           description: >
-            True if binary protocol message is to be treated as quiet message.
+            Set to true if the binary protocol message is to be treated as a quiet message.
 
         - name: memcache.request.cas_unique
           type: int
           description: >
-            CAS (compare-and-swap) identifier if present.
+            The CAS (compare-and-swap) identifier if present.
 
         - name: memcache.response.cas_unique
           type: int
           description: >
-            CAS (compare-and-swap) identifier to be used with CAS based updates
-            (If present).
+            The CAS (compare-and-swap) identifier to be used with CAS-based updates
+            (if present).
 
         - name: memcache.response.stats
           type: list
           description: >
-            List of statistic values returned. Each entry is a dictionary with
-            fields "name" and "value"
+            The list of statistic values returned. Each entry is a dictionary with the 
+            fields "name" and "value".
 
         - name: memcache.response.version
           type: string
           description: >
-            Returned memcache version string.
+            The returned memcache version string.
 
 
     - name: mysql
       type: group
-      description: MySQL specific event fields.
+      description: MySQL-specific event fields.
       fields:
         - name: mysql.iserror
           type: bool
           description: >
-            In case the MySQL query returns an error, this field is set to true.
+           If the MySQL query returns an error, this field is set to true.
 
         - name: mysql.affected_rows
           type: int
           description: >
-            In case of a successful MySQL command, it contains the affected
+            If the MySQL command is successful, this field contains the affected
             number of rows of the last statement.
 
         - name: mysql.insert_id
           description: >
-            In case of a successful ``INSERT`` query, it contains the id of the
+            If the INSERT query is successful, this field contains the id of the
             newly inserted row.
 
         - name: mysql.num_fields
           description: >
-            In case of a successful ``SELECT`` query, it is set to the number
+            If the SELECT query is successful, this field is set to the number
             of fields returned.
 
         - name: mysql.num_rows
           description: >
-            In case of a successful ``SELECT`` query, it is set to the number
+            If the SELECT query is successful, this field is set to the number
             of rows returned.
 
         - name: mysql.query
@@ -675,7 +676,7 @@ event:
 
     - name: pgsql
       type: group
-      description: PostgreSQL specific event fields.
+      description: PostgreSQL-specific event fields.
       fields:
         - name: pgsql.query
           description: >
@@ -684,7 +685,7 @@ event:
         - name: pgsql.iserror
           type: bool
           description: >
-            In case the PgSQL query returns an error, this field is set to true.
+            If the PgSQL query returns an error, this field is set to true.
 
         - name: pgsql.error_code
           description: The PostgreSQL error code.
@@ -702,12 +703,12 @@ event:
 
         - name: pgsql.num_fields
           description: >
-            In case of a successful ``SELECT`` query, it is set to the number
+            If the SELECT query if successful, this field is set to the number
             of fields returned.
 
         - name: pgsql.num_rows
           description: >
-            In case of a successful ``SELECT`` query, it is set to the number
+            If the SELECT query if successful, this field is set to the number
             of rows returned.
 
     - name: thrift
@@ -716,8 +717,8 @@ event:
       fields:
         - name: thrift.params
           description: >
-            The RPC method call parameters in human readable format. If the IDL
-            files are available, the parameters are using names whenever possible.
+            The RPC method call parameters in a human readable format. If the IDL
+            files are available, the parameters use names whenever possible.
             Otherwise, the IDs from the message are used.
 
         - name: thrift.service
@@ -727,42 +728,42 @@ event:
         - name: thrift.return_value
           description: >
             The value returned by the Thrift-RPC call. This is encoded in a human
-            readable way.
+            readable format.
 
         - name: thrift.exceptions
           description: >
-            If the call resulted in exceptions, this field contains them in a human
-            readable form
+            If the call resulted in exceptions, this field contains the exceptions in a human
+            readable format.
 
     - name: redis
       type: group
-      description: Redis specific event fields.
+      description: Redis-specific event fields.
       fields:
         - name: redis.return_value
           description: >
-            The return value of the Redis command in human readable form.
+            The return value of the Redis command in a human readable format.
 
         - name: redis.error
           description: >
             If the Redis command has resulted in an error, this field contains the
-            error message as returned by the Redis server.
+            error message returned by the Redis server.
 
     - name: mongodb
       type: group
       description: >
-         MongoDB specific event fields. These fields mirror closely
+         MongoDB-specific event fields. These fields mirror closely
          the fields for the MongoDB wire protocol. The higher level fields
-         (e.g. `query`, `resource`) apply to MongoDB events as well.
+         (for example, `query` and `resource`) apply to MongoDB events as well.
       fields:
         - name: mongodb.error
           description: >
             If the MongoDB request has resulted in an error, this field contains the
-            error message as returned by the server.
+            error message returned by the server.
         - name: mongodb.fullCollectionName
           description: >
             The full collection name.
             The full collection name is the concatenation of the database name with the collection name,
-            using a . for the concatenation.
+            using a dot (.) for the concatenation.
             For example, for the database foo and the collection bar, the full collection name is foo.bar.
         - name: mongodb.numberToSkip
           type: number
@@ -776,31 +777,31 @@ event:
         - name: mongodb.numberReturned
           type: number
           description: >
-            Number of documents in the reply
+            The number of documents in the reply.
         - name: mongodb.startingFrom
           description: >
-            Where in the cursor this reply is starting
+            Where in the cursor this reply is starting.
         - name: mongodb.query
           description: >
-            JSON document that represents the query.
+            A JSON document that represents the query.
             The query will contain one or more elements, all of which must match for a document
             to be included in the result set.
             Possible elements include $query, $orderby, $hint, $explain, and $snapshot.
         - name: mongodb.returnFieldsSelector
           description: >
-            JSON document that limits the fields in the returned documents.
+            A JSON document that limits the fields in the returned documents.
             The returnFieldsSelector contains one or more elements, each of which is the name of a field that should be returned,
-            and and the integer value 1.
+            and the integer value 1.
         - name: mongodb.selector
           description: >
-            BSON document that specifies the query for selection of the document to update or delete.
+            A BSON document that specifies the query for selecting the document to update or delete.
         - name: mongodb.update
           description: >
-            BSON document that specifies the update to be performed.
-            For information on specifying updates see the Update Operations documentation from the MongoDB Manual.
+            A BSON document that specifies the update to be performed.
+            For information on specifying updates, see the Update Operations documentation from the MongoDB Manual.
         - name: mongodb.cursorId
           description: >
-            Cursor identifier that came in the OP_REPLY. This must be the value that came from the database.
+            The cursor identifier returned in the OP_REPLY. This must be the value that was returned from the database.
 
 raw:
   type: group
@@ -827,7 +828,7 @@ measurements:
   fields:
     - name: responsetime
       description: >
-        The wall clock time it took to for the transaction to complete.
+        The wall clock time it took to complete the transaction.
         The precision is in milliseconds.
       type: int
 
@@ -838,14 +839,14 @@ measurements:
     - name: bytes_in
       description: >
         The number of bytes of the request. Note that this size is
-        the application layer message length, without the length of IP or
+        the application layer message length, without the length of the IP or
         TCP headers.
       type: int
 
     - name: bytes_out
       description: >
         The number of bytes of the response. Note that this size is
-        the application layer message length, without the length of IP or
+        the application layer message length, without the length of the IP or
         TCP headers.
       type: int
 
@@ -854,7 +855,7 @@ measurements:
       description: >
         The time it takes to query the name server for a given request.
         This is typically used for RUM (real-user-monitoring) but can
-        also have values for server to server communication when DNS
+        also have values for server-to-server communication when DNS
         is used for service discovery.
         The precision is in microseconds.
 
@@ -877,6 +878,6 @@ measurements:
       type: int
       description: >
         In RUM (real-user-monitoring), the total time it takes for the
-        DOM to be loaded. In terms of W3 Navigation Timing API, this is
+        DOM to be loaded. In terms of the W3 Navigation Timing API, this is
         the difference between `domContentLoadedEnd` and
         `domContentLoadedStart`.


### PR DESCRIPTION
Edits to improve clarity and consistency with other doc. I plan to circle back and fix the formatting of the command line options in the libbeat doc because I realized that the fonts used in our heading styles make it impossible to distinguish between a capital I and a lowercase l (see what I mean!!). One might argue that this is a compelling reason to avoid using those letters as command line args. :-) But for now, I'll just format them using monospace font.

@urso You might want to review the changes that describe the output fields. Most of the changes are minor.