### PR TITLE
Empty DNS request crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 - Packetbeat will now exit if a configuration error is detected. #357
+- Fixed an issue handling DNS requests containing no questions. #369
 
 ### Added
 

--- a/protos/dns/dns.go
+++ b/protos/dns/dns.go
@@ -406,8 +406,10 @@ func (dns *Dns) publishTransaction(t *DnsTransaction) {
 		event["bytes_out"] = t.Response.Length
 		event["responsetime"] = int32(t.Response.Ts.Sub(t.ts).Nanoseconds() / 1e6)
 		event["method"] = dnsOpCodeToString(t.Request.Data.OpCode)
-		event["query"] = dnsQuestionToString(t.Request.Data.Questions[0])
-		event["resource"] = nameToString(t.Request.Data.Questions[0].Name)
+		if len(t.Request.Data.Questions) > 0 {
+			event["query"] = dnsQuestionToString(t.Request.Data.Questions[0])
+			event["resource"] = nameToString(t.Request.Data.Questions[0].Name)
+		}
 		addDnsToMapStr(dnsEvent, t.Response.Data, dns.Include_authorities,
 			dns.Include_additionals)
 
@@ -424,8 +426,10 @@ func (dns *Dns) publishTransaction(t *DnsTransaction) {
 	} else if t.Request != nil {
 		event["bytes_in"] = t.Request.Length
 		event["method"] = dnsOpCodeToString(t.Request.Data.OpCode)
-		event["query"] = dnsQuestionToString(t.Request.Data.Questions[0])
-		event["resource"] = nameToString(t.Request.Data.Questions[0].Name)
+		if len(t.Request.Data.Questions) > 0 {
+			event["query"] = dnsQuestionToString(t.Request.Data.Questions[0])
+			event["resource"] = nameToString(t.Request.Data.Questions[0].Name)
+		}
 		addDnsToMapStr(dnsEvent, t.Request.Data, dns.Include_authorities,
 			dns.Include_additionals)
 
@@ -435,8 +439,10 @@ func (dns *Dns) publishTransaction(t *DnsTransaction) {
 	} else if t.Response != nil {
 		event["bytes_out"] = t.Response.Length
 		event["method"] = dnsOpCodeToString(t.Response.Data.OpCode)
-		event["query"] = dnsQuestionToString(t.Response.Data.Questions[0])
-		event["resource"] = nameToString(t.Response.Data.Questions[0].Name)
+		if len(t.Response.Data.Questions) > 0 {
+			event["query"] = dnsQuestionToString(t.Response.Data.Questions[0])
+			event["resource"] = nameToString(t.Response.Data.Questions[0].Name)
+		}
 		addDnsToMapStr(dnsEvent, t.Response.Data, dns.Include_authorities,
 			dns.Include_additionals)
 		if dns.Send_response {

--- a/protos/dns/dns_test.go
+++ b/protos/dns/dns_test.go
@@ -373,6 +373,34 @@ func TestExpireTransaction(t *testing.T) {
 	assert.Equal(t, NoResponse, mapValue(t, m, "notes"))
 }
 
+// Verify that an empty DNS request packet can be published.
+func TestPublishTransaction_emptyDnsRequest(t *testing.T) {
+	dns := newDns(testing.Verbose())
+
+	trans := newTransaction(time.Now(), DnsTuple{}, common.CmdlineTuple{})
+	trans.Request = &DnsMessage{
+		Data: &layers.DNS{},
+	}
+	dns.publishTransaction(trans)
+
+	m := expectResult(t, dns)
+	assert.Equal(t, common.ERROR_STATUS, mapValue(t, m, "status"))
+}
+
+// Verify that an empty DNS response packet can be published.
+func TestPublishTransaction_emptyDnsResponse(t *testing.T) {
+	dns := newDns(testing.Verbose())
+
+	trans := newTransaction(time.Now(), DnsTuple{}, common.CmdlineTuple{})
+	trans.Response = &DnsMessage{
+		Data: &layers.DNS{},
+	}
+	dns.publishTransaction(trans)
+
+	m := expectResult(t, dns)
+	assert.Equal(t, common.ERROR_STATUS, mapValue(t, m, "status"))
+}
+
 // Benchmarks UDP parsing for the given test message.
 func benchmarkUdp(b *testing.B, q DnsTestMessage) {
 	dns := newDns(false)


### PR DESCRIPTION
Fix panic caused when marshaling DNS transaction to a MapStr that contains a request or response without any questions.

Closes #369