### PR TITLE
Capitalizes Reference in guide title to fix refression

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Packetbeat reference
+= Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.0.0
 :version: 1.0.0
 


### PR DESCRIPTION
This was regressed during a merge/conflict resolution from another branch. Changing the name back to use consistent capitalization. 