### PR TITLE
fix mongodb message correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 - Fix errors redis parser when messages are split in multiple TCP segments. #402
 - Fix errors in redis parser when length prefixed strings contain sequences of CRLF. #402
 - Fix errors in redis parser when dealing with nested arrays. #402
+- Improve MongoDB message correlation. #377
 
 ### Added
 - Added piping support to redis protocol. #402

--- a/protos/mongodb/mongodb.go
+++ b/protos/mongodb/mongodb.go
@@ -24,18 +24,16 @@ type Mongodb struct {
 	MaxDocs      int
 	MaxDocLength int
 
-	transactions       *common.Cache
+	requests           *common.Cache
+	responses          *common.Cache
 	transactionTimeout time.Duration
 
 	results publisher.Client
 }
 
-func (mongodb *Mongodb) getTransaction(k common.HashableTcpTuple) *transaction {
-	v := mongodb.transactions.Get(k)
-	if v != nil {
-		return v.(*transaction)
-	}
-	return nil
+type transactionKey struct {
+	tcp common.HashableTcpTuple
+	id  int
 }
 
 func (mongodb *Mongodb) InitDefaults() {
@@ -82,10 +80,14 @@ func (mongodb *Mongodb) Init(test_mode bool, results publisher.Client) error {
 		}
 	}
 
-	mongodb.transactions = common.NewCache(
+	mongodb.requests = common.NewCache(
 		mongodb.transactionTimeout,
 		protos.DefaultTransactionHashSize)
-	mongodb.transactions.StartJanitor(mongodb.transactionTimeout)
+	mongodb.requests.StartJanitor(mongodb.transactionTimeout)
+	mongodb.responses = common.NewCache(
+		mongodb.transactionTimeout,
+		protos.DefaultTransactionHashSize)
+	mongodb.responses.StartJanitor(mongodb.transactionTimeout)
 	mongodb.results = results
 
 	return nil
@@ -139,6 +141,7 @@ func (mongodb *Mongodb) doParse(
 	st := conn.Streams[dir]
 	if st == nil {
 		st = newStream(pkt, tcptuple)
+		conn.Streams[dir] = st
 		debugf("new stream: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
 	} else {
 		// concatenate bytes
@@ -172,7 +175,7 @@ func (mongodb *Mongodb) doParse(
 
 		// all ok, go to next level and reset stream for new message
 		debugf("MongoDB message complete")
-		mongodb.handleMongodb(st.message, tcptuple, dir)
+		mongodb.handleMongodb(conn, st.message, tcptuple, dir)
 		st.PrepareForNewMessage()
 	}
 
@@ -188,8 +191,12 @@ func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *stream {
 	return s
 }
 
-func (mongodb *Mongodb) handleMongodb(m *mongodbMessage, tcptuple *common.TcpTuple,
-	dir uint8) {
+func (mongodb *Mongodb) handleMongodb(
+	conn *mongodbConnectionData,
+	m *mongodbMessage,
+	tcptuple *common.TcpTuple,
+	dir uint8,
+) {
 
 	m.TcpTuple = *tcptuple
 	m.Direction = dir
@@ -197,85 +204,112 @@ func (mongodb *Mongodb) handleMongodb(m *mongodbMessage, tcptuple *common.TcpTup
 
 	if m.IsResponse {
 		debugf("MongoDB response message")
-		mongodb.receivedMongodbResponse(m)
+		mongodb.onResponse(conn, m)
 	} else {
 		debugf("MongoDB request message")
-		mongodb.receivedMongodbRequest(m)
+		mongodb.onRequest(conn, m)
 	}
 }
 
-func (mongodb *Mongodb) receivedMongodbRequest(msg *mongodbMessage) {
-	// Add it to the HT
-	tuple := msg.TcpTuple
-
-	trans := mongodb.getTransaction(tuple.Hashable())
-	if trans != nil {
-		if trans.Mongodb != nil {
-			logp.Warn("Two requests without a Response. Dropping old request")
-		}
-	} else {
-		debugf("Initialize new transaction from request")
-		trans = &transaction{Type: "mongodb", tuple: tuple}
-		mongodb.transactions.Put(tuple.Hashable(), trans)
+func (mongodb *Mongodb) onRequest(conn *mongodbConnectionData, msg *mongodbMessage) {
+	// publish request only transaction
+	if !awaitsReply(msg.opCode) {
+		mongodb.onTransComplete(msg, nil)
+		return
 	}
 
-	trans.Mongodb = common.MapStr{}
+	id := msg.requestId
+	key := transactionKey{tcp: msg.TcpTuple.Hashable(), id: id}
 
-	trans.event = msg.event
+	// try to find matching response potentially inserted before
+	if v := mongodb.responses.Delete(key); v != nil {
+		resp := v.(*mongodbMessage)
+		mongodb.onTransComplete(msg, resp)
+		return
+	}
 
-	trans.method = msg.method
-
-	trans.cmdline = msg.CmdlineTuple
-	trans.ts = msg.Ts
-	trans.Ts = int64(trans.ts.UnixNano() / 1000) // transactions have microseconds resolution
-	trans.JsTs = msg.Ts
-	trans.Src = common.Endpoint{
-		Ip:   msg.TcpTuple.Src_ip.String(),
-		Port: msg.TcpTuple.Src_port,
-		Proc: string(msg.CmdlineTuple.Src),
+	// insert into cache for correlation
+	old := mongodb.requests.Put(key, msg)
+	if old != nil {
+		logp.Warn("Two requests without a Response. Dropping old request")
 	}
-	trans.Dst = common.Endpoint{
-		Ip:   msg.TcpTuple.Dst_ip.String(),
-		Port: msg.TcpTuple.Dst_port,
-		Proc: string(msg.CmdlineTuple.Dst),
-	}
-	if msg.Direction == tcp.TcpDirectionReverse {
-		trans.Src, trans.Dst = trans.Dst, trans.Src
-	}
-	trans.params = msg.params
-	trans.resource = msg.resource
-	trans.BytesIn = msg.messageLength
 }
 
-func (mongodb *Mongodb) receivedMongodbResponse(msg *mongodbMessage) {
+func (mongodb *Mongodb) onResponse(conn *mongodbConnectionData, msg *mongodbMessage) {
+	id := msg.responseTo
+	key := transactionKey{tcp: msg.TcpTuple.Hashable(), id: id}
 
-	trans := mongodb.getTransaction(msg.TcpTuple.Hashable())
-	if trans == nil {
-		logp.Warn("Response from unknown transaction. Ignoring.")
+	// try to find matching request
+	if v := mongodb.requests.Delete(key); v != nil {
+		requ := v.(*mongodbMessage)
+		mongodb.onTransComplete(requ, msg)
 		return
 	}
-	// check if the request was received
-	if trans.Mongodb == nil {
-		logp.Warn("Response from unknown transaction. Ignoring.")
-		return
 
-	}
+	// insert into cache for correlation
+	mongodb.responses.Put(key, msg)
+}
 
-	// Merge request and response events attributes
-	for k, v := range msg.event {
-		trans.event[k] = v
-	}
-
-	trans.error = msg.error
-	trans.documents = msg.documents
-
-	trans.ResponseTime = int32(msg.Ts.Sub(trans.ts).Nanoseconds() / 1e6) // resp_time in milliseconds
-	trans.BytesOut = msg.messageLength
+func (mongodb *Mongodb) onTransComplete(requ, resp *mongodbMessage) {
+	trans := newTransaction(requ, resp)
+	debugf("Mongodb transaction completed: %s", trans.Mongodb)
 
 	mongodb.publishTransaction(trans)
-	mongodb.transactions.Delete(trans.tuple.Hashable())
+}
 
-	debugf("Mongodb transaction completed: %s", trans.Mongodb)
+func newTransaction(requ, resp *mongodbMessage) *transaction {
+	trans := &transaction{Type: "mongodb"}
+
+	// fill request
+	if requ != nil {
+		trans.tuple = requ.TcpTuple
+
+		trans.Mongodb = common.MapStr{}
+		trans.event = requ.event
+		trans.method = requ.method
+
+		trans.cmdline = requ.CmdlineTuple
+		trans.ts = requ.Ts
+		trans.Ts = int64(trans.ts.UnixNano() / 1000) // transactions have microseconds resolution
+		trans.JsTs = requ.Ts
+		trans.Src = common.Endpoint{
+			Ip:   requ.TcpTuple.Src_ip.String(),
+			Port: requ.TcpTuple.Src_port,
+			Proc: string(requ.CmdlineTuple.Src),
+		}
+		trans.Dst = common.Endpoint{
+			Ip:   requ.TcpTuple.Dst_ip.String(),
+			Port: requ.TcpTuple.Dst_port,
+			Proc: string(requ.CmdlineTuple.Dst),
+		}
+		if requ.Direction == tcp.TcpDirectionReverse {
+			trans.Src, trans.Dst = trans.Dst, trans.Src
+		}
+		trans.params = requ.params
+		trans.resource = requ.resource
+		trans.BytesIn = requ.messageLength
+	}
+
+	// fill response
+	if resp != nil {
+		if requ == nil {
+			// TODO: reverse tuple?
+			trans.tuple = resp.TcpTuple
+		}
+
+		for k, v := range resp.event {
+			trans.event[k] = v
+		}
+
+		trans.error = resp.error
+		trans.documents = resp.documents
+
+		trans.ResponseTime = int32(resp.Ts.Sub(trans.ts).Nanoseconds() / 1e6) // resp_time in milliseconds
+		trans.BytesOut = resp.messageLength
+
+	}
+
+	return trans
 }
 
 func (mongodb *Mongodb) GapInStream(tcptuple *common.TcpTuple, dir uint8,

--- a/protos/mongodb/mongodb_parser.go
+++ b/protos/mongodb/mongodb_parser.go
@@ -11,11 +11,10 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-func mongodbMessageParser(s *MongodbStream) (bool, bool) {
+func mongodbMessageParser(s *stream) (bool, bool) {
 	d := newDecoder(s.data)
 
 	length, err := d.readInt32()
-
 	if err != nil {
 		// Not even enough data to parse length of message
 		return true, false
@@ -37,13 +36,13 @@ func mongodbMessageParser(s *MongodbStream) (bool, bool) {
 	opCode, err := d.readInt32()
 
 	if _, present := OpCodes[opCode]; !present {
-		logp.Err("Unknown operation code: %s", opCode)
+		logp.Err("Unknown operation code: %v", opCode)
 		return false, false
 	}
 	s.message.opCode = OpCodes[opCode]
 	s.message.IsResponse = false // default is that the message is a request. If not opReplyParse will set this to false
 	s.message.ExpectsResponse = false
-	logp.Debug("mongodb", "opCode = "+s.message.opCode)
+	debugf("opCode = %v", s.message.opCode)
 
 	// then split depending on operation type
 	s.message.event = common.MapStr{}
@@ -80,7 +79,7 @@ func mongodbMessageParser(s *MongodbStream) (bool, bool) {
 }
 
 // see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-reply
-func opReplyParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opReplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	m.event["cursorId"], err = d.readInt64()
 	m.event["startingFrom"], err = d.readInt32()
@@ -88,7 +87,7 @@ func opReplyParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	numberReturned, err := d.readInt32()
 	m.event["numberReturned"] = numberReturned
 
-	logp.Debug("mongodb", "Prepare to read %d document from reply", m.event["numberReturned"])
+	debugf("Prepare to read %d document from reply", m.event["numberReturned"])
 
 	documents := make([]interface{}, numberReturned)
 	for i := 0; i < numberReturned; i++ {
@@ -117,7 +116,7 @@ func opReplyParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opMsgParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opMsgParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	var err error
 	m.event["message"], err = d.readCStr()
 	if err != nil {
@@ -127,7 +126,7 @@ func opMsgParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opUpdateParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opUpdateParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	m.event["fullCollectionName"], err = d.readCStr()
 	_, err = d.readInt32() // ignore flags for now
@@ -143,7 +142,7 @@ func opUpdateParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opInsertParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opInsertParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	m.event["fullCollectionName"], err = d.readCStr()
 
@@ -194,7 +193,7 @@ func isDatabaseCommand(key string, val interface{}) bool {
 	return false
 }
 
-func opQueryParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opQueryParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	fullCollectionName, err := d.readCStr()
 	m.event["fullCollectionName"] = fullCollectionName
@@ -212,9 +211,9 @@ func opQueryParse(d *decoder, m *MongodbMessage) (bool, bool) {
 		m.method = "otherCommand"
 		m.resource = fullCollectionName
 		for key, val := range query {
-			logp.Debug("mongodb", "key=%v val=%s", key, val)
+			debugf("key=%v val=%s", key, val)
 			if isDatabaseCommand(key, val) {
-				logp.Debug("mongodb", "is db command")
+				debugf("is db command")
 				col, ok := val.(string)
 				if ok {
 					// replace $cmd with the actual collection name
@@ -239,7 +238,7 @@ func opQueryParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opGetMoreParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opGetMoreParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	m.event["fullCollectionName"], err = d.readCStr()
 	m.event["numberToReturn"], err = d.readInt32()
@@ -252,7 +251,7 @@ func opGetMoreParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opDeleteParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opDeleteParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	m.event["fullCollectionName"], err = d.readCStr()
 	_, err = d.readInt32() // ignore flags for now
@@ -267,7 +266,7 @@ func opDeleteParse(d *decoder, m *MongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opKillCursorsParse(d *decoder, m *MongodbMessage) (bool, bool) {
+func opKillCursorsParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	// TODO ? Or not, content is not very interesting.
 	return true, true
 }
@@ -341,11 +340,11 @@ func (d *decoder) readDocument() (bson.M, error) {
 
 	documentMap := bson.M{}
 
-	logp.Debug("mongodb", "Parse %d bytes document from remaining %d bytes", documentLength, len(d.in)-start)
+	debugf("Parse %d bytes document from remaining %d bytes", documentLength, len(d.in)-start)
 	err = bson.Unmarshal(d.in[start:d.i], documentMap)
 
 	if err != nil {
-		logp.Debug("mongodb", "Unmarshall error %v", err)
+		debugf("Unmarshall error %v", err)
 		return nil, err
 	}
 

--- a/protos/mongodb/mongodb_parser_test.go
+++ b/protos/mongodb/mongodb_parser_test.go
@@ -10,9 +10,9 @@ func TestMongodbParser_messageNotEvenStarted(t *testing.T) {
 	var data []byte
 	data = append(data, 0)
 
-	stream := &MongodbStream{data: data, message: new(MongodbMessage)}
+	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(stream)
+	ok, complete := mongodbMessageParser(st)
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -26,9 +26,9 @@ func TestMongodbParser_mesageNotFinished(t *testing.T) {
 	var data []byte
 	addInt32(data, 100) // length = 100
 
-	stream := &MongodbStream{data: data, message: new(MongodbMessage)}
+	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(stream)
+	ok, complete := mongodbMessageParser(st)
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -46,9 +46,9 @@ func TestMongodbParser_simpleRequest(t *testing.T) {
 	data = addInt32(data, 1000) // opCode = 1000 = OP_MSG
 	data = addCStr(data, "a message")
 
-	stream := &MongodbStream{data: data, message: new(MongodbMessage)}
+	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(stream)
+	ok, complete := mongodbMessageParser(st)
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -65,9 +65,9 @@ func TestMongodbParser_unknownOpCode(t *testing.T) {
 	data = addInt32(data, 0)    // responseTo = 0
 	data = addInt32(data, 5555) // opCode = 5555 = not a valid code
 
-	stream := &MongodbStream{data: data, message: new(MongodbMessage)}
+	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(stream)
+	ok, complete := mongodbMessageParser(st)
 
 	if ok {
 		t.Errorf("Parsing should have returned an error")

--- a/protos/mongodb/mongodb_structs.go
+++ b/protos/mongodb/mongodb_structs.go
@@ -22,7 +22,7 @@ type mongodbMessage struct {
 	messageLength int
 	requestId     int
 	responseTo    int
-	opCode        string
+	opCode        opCode
 
 	// deduced from content. Either an operation from the original wire protocol or the name of a command (passed through a query)
 	// List of commands: http://docs.mongodb.org/manual/reference/command/
@@ -83,9 +83,11 @@ type transaction struct {
 	documents []interface{}
 }
 
+type opCode string
+
 // List of valid mongodb wire protocol operation codes
 // see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#request-opcodes
-var OpCodes = map[int]string{
+var OpCodes = map[int]opCode{
 	1:    "OP_REPLY",
 	1000: "OP_MSG",
 	2001: "OP_UPDATE",
@@ -95,6 +97,10 @@ var OpCodes = map[int]string{
 	2005: "OP_GET_MORE",
 	2006: "OP_DELETE",
 	2007: "OP_KILL_CURSORS",
+}
+
+func awaitsReply(c opCode) bool {
+	return c == "OP_QUERY" || c == "OP_GET_MORE"
 }
 
 // List of mongodb user commands (send throuwh a query of the legacy protocol)

--- a/protos/mongodb/mongodb_structs.go
+++ b/protos/mongodb/mongodb_structs.go
@@ -83,11 +83,23 @@ type transaction struct {
 	documents []interface{}
 }
 
-type opCode string
+type opCode int32
+
+const (
+	opReply      opCode = 1
+	opMsg        opCode = 1000
+	opUpdate     opCode = 2001
+	opInsert     opCode = 2002
+	opReserved   opCode = 2003
+	opQuery      opCode = 2004
+	opGetMore    opCode = 2005
+	opDelete     opCode = 2006
+	opKillCursor opCode = 2007
+)
 
 // List of valid mongodb wire protocol operation codes
 // see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#request-opcodes
-var OpCodes = map[int]opCode{
+var opCodeNames = map[opCode]string{
 	1:    "OP_REPLY",
 	1000: "OP_MSG",
 	2001: "OP_UPDATE",
@@ -99,8 +111,17 @@ var OpCodes = map[int]opCode{
 	2007: "OP_KILL_CURSORS",
 }
 
+func validOpcode(o opCode) bool {
+	_, found := opCodeNames[o]
+	return found
+}
+
+func (o opCode) String() string {
+	return opCodeNames[o]
+}
+
 func awaitsReply(c opCode) bool {
-	return c == "OP_QUERY" || c == "OP_GET_MORE"
+	return c == opQuery || c == opGetMore
 }
 
 // List of mongodb user commands (send throuwh a query of the legacy protocol)

--- a/protos/mongodb/mongodb_structs.go
+++ b/protos/mongodb/mongodb_structs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/elastic/libbeat/common"
 )
 
-type MongodbMessage struct {
+type mongodbMessage struct {
 	Ts time.Time
 
 	TcpTuple     common.TcpTuple
@@ -39,29 +39,28 @@ type MongodbMessage struct {
 }
 
 // Represent a stream being parsed that contains a mongodb message
-type MongodbStream struct {
+type stream struct {
 	tcptuple *common.TcpTuple
 
-	data []byte
-
-	message *MongodbMessage
+	data    []byte
+	message *mongodbMessage
 }
 
 // Parser moves to next message in stream
-func (stream *MongodbStream) PrepareForNewMessage() {
-	stream.data = stream.data[stream.message.messageLength:]
-	stream.message = nil
+func (st *stream) PrepareForNewMessage() {
+	st.data = st.data[st.message.messageLength:]
+	st.message = nil
 }
 
 // The private data of a parser instance
 // is composed of 2 potentially active streams: incoming, outgoing
-type mongodbPrivateData struct {
-	Data [2]*MongodbStream
+type mongodbConnectionData struct {
+	Streams [2]*stream
 }
 
 // Represent a full mongodb transaction (request/reply)
 // These transactions are the end product of this parser
-type MongodbTransaction struct {
+type transaction struct {
 	Type         string
 	tuple        common.TcpTuple
 	cmdline      *common.CmdlineTuple

--- a/protos/mongodb/mongodb_test.go
+++ b/protos/mongodb/mongodb_test.go
@@ -100,7 +100,7 @@ func TestSimpleFindLimit1(t *testing.T) {
 	req := protos.Packet{Payload: req_data}
 	resp := protos.Packet{Payload: resp_data}
 
-	private := protos.ProtocolData(new(mongodbPrivateData))
+	private := protos.ProtocolData(new(mongodbConnectionData))
 
 	private = mongodb.Parse(&req, tcptuple, 0, private)
 	private = mongodb.Parse(&resp, tcptuple, 1, private)
@@ -121,8 +121,8 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 	}
 
 	mongodb := MongodbModForTests()
-	mongodb.Send_request = true
-	mongodb.Send_response = true
+	mongodb.SendRequest = true
+	mongodb.SendResponse = true
 
 	// request and response from tests/pcaps/mongo_one_row.pcap
 	req_data, err := hex.DecodeString(
@@ -174,7 +174,7 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 	tcptuple := testTcpTuple()
 	req := protos.Packet{Payload: req_data}
 
-	private := protos.ProtocolData(new(mongodbPrivateData))
+	private := protos.ProtocolData(new(mongodbConnectionData))
 
 	private = mongodb.Parse(&req, tcptuple, 0, private)
 
@@ -198,13 +198,13 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 
 func TestReconstructQuery(t *testing.T) {
 	type io struct {
-		Input  MongodbTransaction
+		Input  transaction
 		Full   bool
 		Output string
 	}
 	tests := []io{
 		io{
-			Input: MongodbTransaction{
+			Input: transaction{
 				resource: "test.col",
 				method:   "find",
 				event: map[string]interface{}{
@@ -219,7 +219,7 @@ func TestReconstructQuery(t *testing.T) {
 			Output: `test.col.find({"me":"you"}).skip(3).limit(2)`,
 		},
 		io{
-			Input: MongodbTransaction{
+			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
 				params: map[string]interface{}{
@@ -230,7 +230,7 @@ func TestReconstructQuery(t *testing.T) {
 			Output: `test.col.insert({"documents":"you"})`,
 		},
 		io{
-			Input: MongodbTransaction{
+			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
 				params: map[string]interface{}{
@@ -256,15 +256,15 @@ func TestMaxDocs(t *testing.T) {
 	}
 
 	// more docs than configured
-	trans := MongodbTransaction{
+	trans := transaction{
 		documents: []interface{}{
 			1, 2, 3, 4, 5, 6, 7, 8,
 		},
 	}
 
 	mongodb := MongodbModForTests()
-	mongodb.Send_response = true
-	mongodb.Max_docs = 3
+	mongodb.SendResponse = true
+	mongodb.MaxDocs = 3
 
 	mongodb.publishTransaction(&trans)
 
@@ -273,7 +273,7 @@ func TestMaxDocs(t *testing.T) {
 	assert.Equal(t, "1\n2\n3\n[...]", res["response"])
 
 	// exactly the same number of docs
-	trans = MongodbTransaction{
+	trans = transaction{
 		documents: []interface{}{
 			1, 2, 3,
 		},
@@ -284,7 +284,7 @@ func TestMaxDocs(t *testing.T) {
 	assert.Equal(t, "1\n2\n3", res["response"])
 
 	// less docs
-	trans = MongodbTransaction{
+	trans = transaction{
 		documents: []interface{}{
 			1, 2,
 		},
@@ -295,12 +295,12 @@ func TestMaxDocs(t *testing.T) {
 	assert.Equal(t, "1\n2", res["response"])
 
 	// unlimited
-	trans = MongodbTransaction{
+	trans = transaction{
 		documents: []interface{}{
 			1, 2, 3, 4,
 		},
 	}
-	mongodb.Max_docs = 0
+	mongodb.MaxDocs = 0
 	mongodb.publishTransaction(&trans)
 	res = expectTransaction(t, mongodb)
 	assert.Equal(t, "1\n2\n3\n4", res["response"])
@@ -312,7 +312,7 @@ func TestMaxDocSize(t *testing.T) {
 	}
 
 	// more docs than configured
-	trans := MongodbTransaction{
+	trans := transaction{
 		documents: []interface{}{
 			"1234567",
 			"123",
@@ -321,8 +321,8 @@ func TestMaxDocSize(t *testing.T) {
 	}
 
 	mongodb := MongodbModForTests()
-	mongodb.Send_response = true
-	mongodb.Max_doc_length = 5
+	mongodb.SendResponse = true
+	mongodb.MaxDocLength = 5
 
 	mongodb.publishTransaction(&trans)
 


### PR DESCRIPTION
- Publish request only transactions immediately
- Use requestID and responseTo ids for correlating responses to requests

resolves #377