### PR TITLE
Separate http parser from http.go file

### DIFF
--- a/beat/packetbeat.go
+++ b/beat/packetbeat.go
@@ -32,7 +32,7 @@ import (
 )
 
 var EnabledProtocolPlugins map[protos.Protocol]protos.ProtocolPlugin = map[protos.Protocol]protos.ProtocolPlugin{
-	protos.HttpProtocol:     new(http.Http),
+	protos.HttpProtocol:     new(http.HTTP),
 	protos.MemcacheProtocol: new(memcache.Memcache),
 	protos.MysqlProtocol:    new(mysql.Mysql),
 	protos.PgsqlProtocol:    new(pgsql.Pgsql),

--- a/protos/http/http.go
+++ b/protos/http/http.go
@@ -2,10 +2,8 @@ package http
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -19,55 +17,20 @@ import (
 	"github.com/elastic/packetbeat/protos/tcp"
 )
 
+var debugf = logp.MakeDebug("http")
+var detailedf = logp.MakeDebug("httpdetailed")
+
+type parserState uint8
+
 const (
-	START = iota
-	FLINE
-	HEADERS
-	BODY
-	BODY_CHUNKED_START
-	BODY_CHUNKED
-	BODY_CHUNKED_WAIT_FINAL_CRLF
+	stateStart parserState = iota
+	stateFLine
+	stateHeaders
+	stateBody
+	stateBodyChunkedStart
+	stateBodyChunked
+	stateBodyChunkedWaitFinalCRLF
 )
-
-// Http Message
-type HttpMessage struct {
-	Ts               time.Time
-	hasContentLength bool
-	headerOffset     int
-	bodyOffset       int
-	version_major    uint8
-	version_minor    uint8
-	connection       string
-	chunked_length   int
-	chunked_body     []byte
-
-	IsRequest    bool
-	TcpTuple     common.TcpTuple
-	CmdlineTuple *common.CmdlineTuple
-	Direction    uint8
-	//Request Info
-	FirstLine    string
-	RequestUri   string
-	Method       string
-	StatusCode   uint16
-	StatusPhrase string
-	Real_ip      string
-	// Http Headers
-	ContentLength    int
-	ContentType      string
-	TransferEncoding string
-	Headers          map[string]string
-	Body             string
-	Size             uint64
-	//Raw Data
-	Raw []byte
-
-	Notes []string
-
-	//Timing
-	start int
-	end   int
-}
 
 type HttpStream struct {
 	tcptuple *common.TcpTuple
@@ -75,10 +38,14 @@ type HttpStream struct {
 	data []byte
 
 	parseOffset  int
-	parseState   int
+	parseState   parserState
 	bodyReceived int
 
 	message *HttpMessage
+}
+
+type httpPrivateData struct {
+	Data [2]*HttpStream
 }
 
 type HttpTransaction struct {
@@ -108,16 +75,14 @@ type HttpTransaction struct {
 
 type Http struct {
 	// config
-	Ports                []int
-	Send_request         bool
-	Send_response        bool
-	Send_headers         bool
-	Send_all_headers     bool
-	Headers_whitelist    map[string]bool
-	Split_cookie         bool
-	Real_ip_header       string
-	Hide_keywords        []string
-	Redact_authorization bool
+	Ports               []int
+	SendRequest         bool
+	SendResponse        bool
+	SplitCookie         bool
+	HideKeywords        []string
+	RedactAuthorization bool
+
+	parserConfig parserConfig
 
 	transactions       *common.Cache
 	transactionTimeout time.Duration
@@ -134,9 +99,9 @@ func (http *Http) getTransaction(k common.HashableTcpTuple) *HttpTransaction {
 }
 
 func (http *Http) InitDefaults() {
-	http.Send_request = false
-	http.Send_response = false
-	http.Redact_authorization = false
+	http.SendRequest = false
+	http.SendResponse = false
+	http.RedactAuthorization = false
 	http.transactionTimeout = protos.DefaultTransactionExpiration
 }
 
@@ -145,36 +110,36 @@ func (http *Http) SetFromConfig(config config.Http) (err error) {
 	http.Ports = config.Ports
 
 	if config.SendRequest != nil {
-		http.Send_request = *config.SendRequest
+		http.SendRequest = *config.SendRequest
 	}
 	if config.SendResponse != nil {
-		http.Send_response = *config.SendResponse
+		http.SendResponse = *config.SendResponse
 	}
-	http.Hide_keywords = config.Hide_keywords
+	http.HideKeywords = config.Hide_keywords
 	if config.Redact_authorization != nil {
-		http.Redact_authorization = *config.Redact_authorization
+		http.RedactAuthorization = *config.Redact_authorization
 	}
 
 	if config.Send_all_headers != nil {
-		http.Send_headers = true
-		http.Send_all_headers = true
+		http.parserConfig.SendHeaders = true
+		http.parserConfig.SendAllHeaders = true
 	} else {
 		if len(config.Send_headers) > 0 {
-			http.Send_headers = true
+			http.parserConfig.SendHeaders = true
 
-			http.Headers_whitelist = map[string]bool{}
+			http.parserConfig.HeadersWhitelist = map[string]bool{}
 			for _, hdr := range config.Send_headers {
-				http.Headers_whitelist[strings.ToLower(hdr)] = true
+				http.parserConfig.HeadersWhitelist[strings.ToLower(hdr)] = true
 			}
 		}
 	}
 
 	if config.Split_cookie != nil {
-		http.Split_cookie = *config.Split_cookie
+		http.SplitCookie = *config.Split_cookie
 	}
 
 	if config.Real_ip_header != nil {
-		http.Real_ip_header = strings.ToLower(*config.Real_ip_header)
+		http.parserConfig.RealIPHeader = strings.ToLower(*config.Real_ip_header)
 	}
 
 	if config.TransactionTimeout != nil && *config.TransactionTimeout > 0 {
@@ -207,259 +172,6 @@ func (http *Http) Init(test_mode bool, results publisher.Client) error {
 	return nil
 }
 
-func parseVersion(s []byte) (uint8, uint8, error) {
-	if len(s) < 3 {
-		return 0, 0, errors.New("Invalid version")
-	}
-
-	major, _ := strconv.Atoi(string(s[0]))
-	minor, _ := strconv.Atoi(string(s[2]))
-
-	return uint8(major), uint8(minor), nil
-}
-
-func parseResponseStatus(s []byte) (uint16, string, error) {
-
-	logp.Debug("http", "parseResponseStatus: %s", s)
-
-	p := bytes.Index(s, []byte(" "))
-	if p == -1 {
-		return 0, "", errors.New("Not beeing able to identify status code")
-	}
-
-	status_code, _ := strconv.Atoi(string(s[0:p]))
-
-	p = bytes.LastIndex(s, []byte(" "))
-	if p == -1 {
-		return uint16(status_code), "", errors.New("Not beeing able to identify status code")
-	}
-	status_phrase := s[p+1:]
-	return uint16(status_code), string(status_phrase), nil
-}
-
-func (http *Http) parseHeader(m *HttpMessage, data []byte) (bool, bool, int) {
-	if m.Headers == nil {
-		m.Headers = make(map[string]string)
-	}
-	i := bytes.Index(data, []byte(":"))
-	if i == -1 {
-		// Expected \":\" in headers. Assuming incomplete"
-		return true, false, 0
-	}
-
-	logp.Debug("httpdetailed", "Data: %s", data)
-	logp.Debug("httpdetailed", "Header: %s", data[:i])
-
-	// skip folding line
-	for p := i + 1; p < len(data); {
-		q := bytes.Index(data[p:], []byte("\r\n"))
-		if q == -1 {
-			// Assuming incomplete
-			return true, false, 0
-		}
-		p += q
-		logp.Debug("httpdetailed", "HV: %s\n", data[i+1:p])
-		if len(data) > p && (data[p+1] == ' ' || data[p+1] == '\t') {
-			p = p + 2
-		} else {
-			headerName := strings.ToLower(string(data[:i]))
-			headerVal := string(bytes.Trim(data[i+1:p], " \t"))
-			logp.Debug("http", "Header: '%s' Value: '%s'\n", headerName, headerVal)
-
-			// Headers we need for parsing. Make sure we always
-			// capture their value
-			if headerName == "content-length" {
-				m.ContentLength, _ = strconv.Atoi(headerVal)
-				m.hasContentLength = true
-			} else if headerName == "content-type" {
-				m.ContentType = headerVal
-			} else if headerName == "transfer-encoding" {
-				m.TransferEncoding = headerVal
-			} else if headerName == "connection" {
-				m.connection = headerVal
-			}
-			if len(http.Real_ip_header) > 0 && headerName == http.Real_ip_header {
-				m.Real_ip = headerVal
-			}
-
-			if http.Send_headers {
-				if !http.Send_all_headers {
-					_, exists := http.Headers_whitelist[headerName]
-					if !exists {
-						return true, true, p + 2
-					}
-				}
-				if val, ok := m.Headers[headerName]; ok {
-					m.Headers[headerName] = val + ", " + headerVal
-				} else {
-					m.Headers[headerName] = headerVal
-				}
-			}
-
-			return true, true, p + 2
-		}
-	}
-
-	return true, false, len(data)
-}
-
-func (http *Http) messageParser(s *HttpStream) (bool, bool) {
-
-	var cont, ok, complete bool
-	m := s.message
-
-	for s.parseOffset < len(s.data) {
-		switch s.parseState {
-		case START:
-			m.start = s.parseOffset
-			i := bytes.Index(s.data[s.parseOffset:], []byte("\r\n"))
-			if i == -1 {
-				return true, false
-			}
-
-			// Very basic tests on the first line. Just to check that
-			// we have what looks as an HTTP message
-			var version []byte
-			var err error
-			fline := s.data[s.parseOffset:i]
-			if len(fline) < 8 {
-				logp.Debug("http", "First line too small")
-				return false, false
-			}
-			if bytes.Equal(fline[0:5], []byte("HTTP/")) {
-				//RESPONSE
-				m.IsRequest = false
-				version = fline[5:8]
-				m.StatusCode, m.StatusPhrase, err = parseResponseStatus(fline[9:])
-				if err != nil {
-					logp.Warn("Failed to understand HTTP response status: %s", fline[9:])
-					return false, false
-				}
-				logp.Debug("http", "HTTP status_code=%d, status_phrase=%s", m.StatusCode, m.StatusPhrase)
-
-			} else {
-				// REQUEST
-				slices := bytes.Fields(fline)
-				if len(slices) != 3 {
-					logp.Debug("http", "Couldn't understand HTTP request: %s", fline)
-					return false, false
-				}
-
-				m.Method = string(slices[0])
-				m.RequestUri = string(slices[1])
-
-				if bytes.Equal(slices[2][:5], []byte("HTTP/")) {
-					m.IsRequest = true
-					version = slices[2][5:]
-					m.FirstLine = string(fline)
-				} else {
-					logp.Debug("http", "Couldn't understand HTTP version: %s", fline)
-					return false, false
-				}
-				logp.Debug("http", "HTTP Method=%s, RequestUri=%s", m.Method, m.RequestUri)
-			}
-
-			m.version_major, m.version_minor, err = parseVersion(version)
-			if err != nil {
-				logp.Debug("http", "Failed to understand HTTP version: %s", version)
-				m.version_major = 1
-				m.version_minor = 0
-			}
-			logp.Debug("http", "HTTP version %d.%d", m.version_major, m.version_minor)
-
-			// ok so far
-			s.parseOffset = i + 2
-			m.headerOffset = s.parseOffset
-			s.parseState = HEADERS
-
-		case HEADERS:
-
-			if len(s.data)-s.parseOffset >= 2 &&
-				bytes.Equal(s.data[s.parseOffset:s.parseOffset+2], []byte("\r\n")) {
-				// EOH
-				s.parseOffset += 2
-				m.bodyOffset = s.parseOffset
-				if !m.IsRequest && ((100 <= m.StatusCode && m.StatusCode < 200) || m.StatusCode == 204 || m.StatusCode == 304) {
-					//response with a 1xx, 204 , or 304 status  code is always terminated
-					// by the first empty line after the  header fields
-					logp.Debug("http", "Terminate response, status code %d", m.StatusCode)
-					m.end = s.parseOffset
-					m.Size = uint64(m.end - m.start)
-					return true, true
-				}
-				if m.TransferEncoding == "chunked" {
-					// support for HTTP/1.1 Chunked transfer
-					// Transfer-Encoding overrides the Content-Length
-					logp.Debug("http", "Read chunked body")
-					s.parseState = BODY_CHUNKED_START
-					continue
-				}
-				if m.ContentLength == 0 && (m.IsRequest || m.hasContentLength) {
-					logp.Debug("http", "Empty content length, ignore body")
-					// Ignore body for request that contains a message body but not a Content-Length
-					m.end = s.parseOffset
-					m.Size = uint64(m.end - m.start)
-					return true, true
-				}
-				logp.Debug("http", "Read body")
-				s.parseState = BODY
-			} else {
-				ok, hfcomplete, offset := http.parseHeader(m, s.data[s.parseOffset:])
-
-				if !ok {
-					return false, false
-				}
-				if !hfcomplete {
-					return true, false
-				}
-				s.parseOffset += offset
-			}
-
-		case BODY:
-			logp.Debug("http", "eat body: %d", s.parseOffset)
-			if !m.hasContentLength && (m.connection == "close" ||
-				(m.version_major == 1 && m.version_minor == 0 &&
-					m.connection != "keep-alive")) {
-
-				// HTTP/1.0 no content length. Add until the end of the connection
-				logp.Debug("http", "close connection, %d", len(s.data)-s.parseOffset)
-				s.bodyReceived += (len(s.data) - s.parseOffset)
-				m.ContentLength += (len(s.data) - s.parseOffset)
-				s.parseOffset = len(s.data)
-				return true, false
-			} else if len(s.data[s.parseOffset:]) >= m.ContentLength-s.bodyReceived {
-				s.parseOffset += (m.ContentLength - s.bodyReceived)
-				m.end = s.parseOffset
-				m.Size = uint64(m.end - m.start)
-				return true, true
-			} else {
-				s.bodyReceived += (len(s.data) - s.parseOffset)
-				s.parseOffset = len(s.data)
-				logp.Debug("http", "bodyReceived: %d", s.bodyReceived)
-				return true, false
-			}
-
-		case BODY_CHUNKED_START:
-			cont, ok, complete = state_body_chunked_start(s, m)
-			if !cont {
-				return ok, complete
-			}
-
-		case BODY_CHUNKED:
-			cont, ok, complete = state_body_chunked(s, m)
-			if !cont {
-				return ok, complete
-			}
-
-		case BODY_CHUNKED_WAIT_FINAL_CRLF:
-			return state_body_chunked_wait_final_crlf(s, m)
-		}
-
-	}
-
-	return true, false
-}
-
 // messageGap is called when a gap of size `nbytes` is found in the
 // tcp stream. Decides if we can ignore the gap or it's a parser error
 // and we need to drop the stream.
@@ -467,19 +179,18 @@ func (http *Http) messageGap(s *HttpStream, nbytes int) (ok bool, complete bool)
 
 	m := s.message
 	switch s.parseState {
-	case START, HEADERS:
+	case stateStart, stateHeaders:
 		// we know we cannot recover from these
 		return false, false
-	case BODY:
-		logp.Debug("http", "gap in body: %d", nbytes)
+	case stateBody:
+		debugf("gap in body: %d", nbytes)
 		if m.IsRequest {
 			m.Notes = append(m.Notes, "Packet loss while capturing the request")
 		} else {
 			m.Notes = append(m.Notes, "Packet loss while capturing the response")
 		}
 		if !m.hasContentLength && (m.connection == "close" ||
-			(m.version_major == 1 && m.version_minor == 0 &&
-				m.connection != "keep-alive")) {
+			(isVersion(m.version, 1, 0) && m.connection != "keep-alive")) {
 
 			s.bodyReceived += nbytes
 			m.ContentLength += nbytes
@@ -497,88 +208,12 @@ func (http *Http) messageGap(s *HttpStream, nbytes int) (ok bool, complete bool)
 	return false, false
 }
 
-func state_body_chunked_wait_final_crlf(s *HttpStream, m *HttpMessage) (ok bool, complete bool) {
-	if len(s.data[s.parseOffset:]) < 2 {
-		return true, false
-	} else {
-		if s.data[s.parseOffset] != '\r' || s.data[s.parseOffset+1] != '\n' {
-			logp.Warn("Expected CRLF sequence at end of message")
-			return false, false
-		}
-		s.parseOffset += 2 // skip final CRLF
-		m.end = s.parseOffset
-		m.Size = uint64(m.end - m.start)
-		return true, true
-	}
-}
-
-func state_body_chunked_start(s *HttpStream, m *HttpMessage) (cont bool, ok bool, complete bool) {
-	// read hexa length
-	i := bytes.Index(s.data[s.parseOffset:], []byte("\r\n"))
-	if i == -1 {
-		return false, true, false
-	}
-	line := string(s.data[s.parseOffset : s.parseOffset+i])
-	_, err := fmt.Sscanf(line, "%x", &m.chunked_length)
-	if err != nil {
-		logp.Warn("Failed to understand chunked body start line")
-		return false, false, false
-	}
-
-	s.parseOffset += i + 2 //+ \r\n
-	if m.chunked_length == 0 {
-		if len(s.data[s.parseOffset:]) < 2 {
-			s.parseState = BODY_CHUNKED_WAIT_FINAL_CRLF
-			return false, true, false
-		}
-		if s.data[s.parseOffset] != '\r' || s.data[s.parseOffset+1] != '\n' {
-			logp.Warn("Expected CRLF sequence at end of message")
-			return false, false, false
-		}
-		s.parseOffset += 2 // skip final CRLF
-
-		m.end = s.parseOffset
-		m.Size = uint64(m.end - m.start)
-		return false, true, true
-	}
-	s.bodyReceived = 0
-	s.parseState = BODY_CHUNKED
-
-	return true, true, false
-}
-
-func state_body_chunked(s *HttpStream, m *HttpMessage) (cont bool, ok bool, complete bool) {
-
-	if len(s.data[s.parseOffset:]) >= m.chunked_length-s.bodyReceived+2 /*\r\n*/ {
-		// Received more data than expected
-		m.chunked_body = append(m.chunked_body, s.data[s.parseOffset:s.parseOffset+m.chunked_length-s.bodyReceived]...)
-		s.parseOffset += (m.chunked_length - s.bodyReceived + 2 /*\r\n*/)
-		m.ContentLength += m.chunked_length
-		s.parseState = BODY_CHUNKED_START
-		return true, true, false
-	} else {
-		if len(s.data[s.parseOffset:]) >= m.chunked_length-s.bodyReceived {
-			// we need need to wait for the +2, else we can crash on next call
-			return false, true, false
-		}
-		// Received less data than expected
-		m.chunked_body = append(m.chunked_body, s.data[s.parseOffset:]...)
-		s.bodyReceived += (len(s.data) - s.parseOffset)
-		s.parseOffset = len(s.data)
-		return false, true, false
-	}
-}
-
 func (stream *HttpStream) PrepareForNewMessage() {
 	stream.data = stream.data[stream.message.end:]
-	stream.parseState = START
+	stream.parseState = stateStart
 	stream.parseOffset = 0
 	stream.bodyReceived = 0
 	stream.message = nil
-}
-
-type httpPrivateData struct {
-	Data [2]*HttpStream
 }
 
 // Called when the parser has identified the boundary
@@ -602,7 +237,7 @@ func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 
 	defer logp.Recover("ParseHttp exception")
 
-	logp.Debug("httpdetailed", "Payload received: [%s]", pkt.Payload)
+	detailedf("Payload received: [%s]", pkt.Payload)
 
 	priv := httpPrivateData{}
 	if private != nil {
@@ -624,7 +259,7 @@ func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 		// concatenate bytes
 		priv.Data[dir].data = append(priv.Data[dir].data, pkt.Payload...)
 		if len(priv.Data[dir].data) > tcp.TCP_MAX_DATA_IN_STREAM {
-			logp.Debug("http", "Stream data too large, dropping TCP stream")
+			debugf("Stream data too large, dropping TCP stream")
 			priv.Data[dir] = nil
 			return priv
 		}
@@ -633,8 +268,9 @@ func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	if stream.message == nil {
 		stream.message = &HttpMessage{Ts: pkt.Ts}
 	}
-	ok, complete := http.messageParser(stream)
 
+	parser := newParser(&http.parserConfig)
+	ok, complete := parser.parse(stream)
 	if !ok {
 		// drop this tcp stream. Will retry parsing with the next
 		// segment in it
@@ -671,7 +307,7 @@ func (http *Http) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 	if stream.message != nil &&
 		len(stream.data[stream.message.start:]) > 0 {
 
-		logp.Debug("httpdetailed", "Publish something on connection FIN")
+		detailedf("Publish something on connection FIN")
 
 		msg := stream.data[stream.message.start:]
 		http.hideHeaders(stream.message, msg)
@@ -706,7 +342,7 @@ func (http *Http) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	}
 
 	ok, complete := http.messageGap(stream, nbytes)
-	logp.Debug("httpdetailed", "messageGap returned ok=%v complete=%v", ok, complete)
+	detailedf("messageGap returned ok=%v complete=%v", ok, complete)
 	if !ok {
 		// on errors, drop stream
 		httpData.Data[dir] = nil
@@ -749,7 +385,7 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 		http.transactions.Put(msg.TcpTuple.Hashable(), trans)
 	}
 
-	logp.Debug("http", "Received request with tuple: %s", msg.TcpTuple)
+	debugf("Received request with tuple: %s", msg.TcpTuple)
 
 	trans.ts = msg.Ts
 	trans.Ts = int64(trans.ts.UnixNano() / 1000)
@@ -769,7 +405,7 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 	}
 
 	// save Raw message
-	if http.Send_request {
+	if http.SendRequest {
 		trans.Request_raw = string(http.cutMessageBody(msg))
 	}
 
@@ -780,16 +416,16 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 
 	trans.Http = common.MapStr{}
 
-	if http.Send_headers {
-		if !http.Split_cookie {
+	if http.parserConfig.SendHeaders {
+		if !http.SplitCookie {
 			trans.Http["request_headers"] = msg.Headers
 		} else {
 			hdrs := common.MapStr{}
-			for hdr_name, hdr_val := range msg.Headers {
-				if hdr_name == "cookie" {
-					hdrs[hdr_name] = splitCookiesHeader(hdr_val)
+			for name, value := range msg.Headers {
+				if name == "cookie" {
+					hdrs[name] = splitCookiesHeader(value)
 				} else {
-					hdrs[hdr_name] = hdr_val
+					hdrs[name] = value
 				}
 			}
 
@@ -811,7 +447,7 @@ func (http *Http) receivedHttpResponse(msg *HttpMessage) {
 	// we need to search the request first.
 	tuple := msg.TcpTuple
 
-	logp.Debug("http", "Received response with tuple: %s", tuple)
+	debugf("Received response with tuple: %s", tuple)
 
 	trans := http.getTransaction(tuple.Hashable())
 	if trans == nil {
@@ -830,16 +466,16 @@ func (http *Http) receivedHttpResponse(msg *HttpMessage) {
 		"content_length": msg.ContentLength,
 	}
 
-	if http.Send_headers {
-		if !http.Split_cookie {
+	if http.parserConfig.SendHeaders {
+		if !http.SplitCookie {
 			response["response_headers"] = msg.Headers
 		} else {
 			hdrs := common.MapStr{}
-			for hdr_name, hdr_val := range msg.Headers {
-				if hdr_name == "set-cookie" {
-					hdrs[hdr_name] = splitCookiesHeader(hdr_val)
+			for name, value := range msg.Headers {
+				if name == "set-cookie" {
+					hdrs[name] = splitCookiesHeader(value)
 				} else {
-					hdrs[hdr_name] = hdr_val
+					hdrs[name] = value
 				}
 			}
 
@@ -854,14 +490,14 @@ func (http *Http) receivedHttpResponse(msg *HttpMessage) {
 	trans.ResponseTime = int32(msg.Ts.Sub(trans.ts).Nanoseconds() / 1e6) // resp_time in milliseconds
 
 	// save Raw message
-	if http.Send_response {
+	if http.SendResponse {
 		trans.Response_raw = string(http.cutMessageBody(msg))
 	}
 
 	http.publishTransaction(trans)
 	http.transactions.Delete(trans.tuple.Hashable())
 
-	logp.Debug("http", "HTTP transaction completed: %s\n", trans.Http)
+	debugf("HTTP transaction completed: %s\n", trans.Http)
 }
 
 func (http *Http) publishTransaction(t *HttpTransaction) {
@@ -880,10 +516,10 @@ func (http *Http) publishTransaction(t *HttpTransaction) {
 		event["status"] = common.ERROR_STATUS
 	}
 	event["responsetime"] = t.ResponseTime
-	if http.Send_request {
+	if http.SendRequest {
 		event["request"] = t.Request_raw
 	}
-	if http.Send_response {
+	if http.SendResponse {
 		event["response"] = t.Response_raw
 	}
 	event["http"] = t.Http
@@ -908,14 +544,6 @@ func (http *Http) publishTransaction(t *HttpTransaction) {
 	http.results.PublishEvent(event)
 }
 
-func parseCookieValue(raw string) string {
-	// Strip the quotes, if present.
-	if len(raw) > 1 && raw[0] == '"' && raw[len(raw)-1] == '"' {
-		raw = raw[1 : len(raw)-1]
-	}
-	return raw
-}
-
 func splitCookiesHeader(headerVal string) map[string]string {
 	cookies := map[string]string{}
 
@@ -931,33 +559,41 @@ func splitCookiesHeader(headerVal string) map[string]string {
 	return cookies
 }
 
+func parseCookieValue(raw string) string {
+	// Strip the quotes, if present.
+	if len(raw) > 1 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		raw = raw[1 : len(raw)-1]
+	}
+	return raw
+}
+
 func (http *Http) cutMessageBody(m *HttpMessage) []byte {
-	raw_msg_cut := []byte{}
+	cutMsg := []byte{}
 
 	// add headers always
-	raw_msg_cut = m.Raw[:m.bodyOffset]
+	cutMsg = m.Raw[:m.bodyOffset]
 
 	// add body
 	if len(m.ContentType) == 0 || http.shouldIncludeInBody(m.ContentType) {
 		if len(m.chunked_body) > 0 {
-			raw_msg_cut = append(raw_msg_cut, m.chunked_body...)
+			cutMsg = append(cutMsg, m.chunked_body...)
 		} else {
-			logp.Debug("http", "Body to include: [%s]", m.Raw[m.bodyOffset:])
-			raw_msg_cut = append(raw_msg_cut, m.Raw[m.bodyOffset:]...)
+			debugf("Body to include: [%s]", m.Raw[m.bodyOffset:])
+			cutMsg = append(cutMsg, m.Raw[m.bodyOffset:]...)
 		}
 	}
 
-	return raw_msg_cut
+	return cutMsg
 }
 
 func (http *Http) shouldIncludeInBody(contenttype string) bool {
-	include_body := config.ConfigSingleton.Protocols.Http.Include_body_for
-	for _, include := range include_body {
+	includedBodies := config.ConfigSingleton.Protocols.Http.Include_body_for
+	for _, include := range includedBodies {
 		if strings.Contains(contenttype, include) {
-			logp.Debug("http", "Should Include Body = true Content-Type "+contenttype+" include_body "+include)
+			debugf("Should Include Body = true Content-Type " + contenttype + " include_body " + include)
 			return true
 		}
-		logp.Debug("http", "Should Include Body = false Content-Type"+contenttype+" include_body "+include)
+		debugf("Should Include Body = false Content-Type" + contenttype + " include_body " + include)
 	}
 	return false
 }
@@ -966,7 +602,7 @@ func (http *Http) hideHeaders(m *HttpMessage, msg []byte) {
 
 	if m.IsRequest {
 		// byte64 != encryption, so obscure it in headers in case of Basic Authentication
-		if http.Redact_authorization {
+		if http.RedactAuthorization {
 
 			redactHeaders := []string{"authorization", "proxy-authorization"}
 			auth_text := []byte("uthorization:") // [aA] case insensitive, also catches Proxy-Authorization:
@@ -975,7 +611,7 @@ func (http *Http) hideHeaders(m *HttpMessage, msg []byte) {
 			authHeaderEndX := m.bodyOffset
 
 			for authHeaderStartX < m.bodyOffset {
-				logp.Debug("http", "looking for authorization from %d to %d", authHeaderStartX, authHeaderEndX)
+				debugf("looking for authorization from %d to %d", authHeaderStartX, authHeaderEndX)
 
 				startOfHeader := bytes.Index(msg[authHeaderStartX:m.bodyOffset], auth_text)
 				if startOfHeader >= 0 {
@@ -989,7 +625,7 @@ func (http *Http) hideHeaders(m *HttpMessage, msg []byte) {
 							authHeaderEndX = m.bodyOffset
 						}
 
-						logp.Debug("http", "Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
+						debugf("Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
 
 						for i := authHeaderStartX + len(auth_text); i < authHeaderEndX; i++ {
 							msg[i] = byte('*')
@@ -1050,14 +686,14 @@ func (http *Http) extractParameters(m *HttpMessage, msg []byte) (path string, pa
 	}
 	params = paramsMap.Encode()
 
-	logp.Debug("httpdetailed", "Parameters: %s", params)
+	detailedf("Parameters: %s", params)
 
 	return
 }
 
 func (http *Http) isSecretParameter(key string) bool {
 
-	for _, keyword := range http.Hide_keywords {
+	for _, keyword := range http.HideKeywords {
 		if strings.ToLower(key) == keyword {
 			return true
 		}

--- a/protos/http/http.go
+++ b/protos/http/http.go
@@ -32,7 +32,7 @@ const (
 	stateBodyChunkedWaitFinalCRLF
 )
 
-type HttpStream struct {
+type stream struct {
 	tcptuple *common.TcpTuple
 
 	data []byte
@@ -41,39 +41,39 @@ type HttpStream struct {
 	parseState   parserState
 	bodyReceived int
 
-	message *HttpMessage
+	message *message
 }
 
-type httpPrivateData struct {
-	Data [2]*HttpStream
+type httpConnectionData struct {
+	Streams [2]*stream
 }
 
-type HttpTransaction struct {
+type transaction struct {
 	Type         string
 	tuple        common.TcpTuple
 	Src          common.Endpoint
 	Dst          common.Endpoint
-	Real_ip      string
+	RealIP       string
 	ResponseTime int32
 	Ts           int64
 	JsTs         time.Time
 	ts           time.Time
 	cmdline      *common.CmdlineTuple
 	Method       string
-	RequestUri   string
+	RequestURI   string
 	Params       string
 	Path         string
 	BytesOut     uint64
 	BytesIn      uint64
 	Notes        []string
 
-	Http common.MapStr
+	HTTP common.MapStr
 
-	Request_raw  string
-	Response_raw string
+	RequestRaw  string
+	ResponseRaw string
 }
 
-type Http struct {
+type HTTP struct {
 	// config
 	Ports               []int
 	SendRequest         bool
@@ -90,22 +90,22 @@ type Http struct {
 	results publisher.Client
 }
 
-func (http *Http) getTransaction(k common.HashableTcpTuple) *HttpTransaction {
+func (http *HTTP) getTransaction(k common.HashableTcpTuple) *transaction {
 	v := http.transactions.Get(k)
 	if v != nil {
-		return v.(*HttpTransaction)
+		return v.(*transaction)
 	}
 	return nil
 }
 
-func (http *Http) InitDefaults() {
+func (http *HTTP) InitDefaults() {
 	http.SendRequest = false
 	http.SendResponse = false
 	http.RedactAuthorization = false
 	http.transactionTimeout = protos.DefaultTransactionExpiration
 }
 
-func (http *Http) SetFromConfig(config config.Http) (err error) {
+func (http *HTTP) SetFromConfig(config config.Http) (err error) {
 
 	http.Ports = config.Ports
 
@@ -149,11 +149,11 @@ func (http *Http) SetFromConfig(config config.Http) (err error) {
 	return nil
 }
 
-func (http *Http) GetPorts() []int {
+func (http *HTTP) GetPorts() []int {
 	return http.Ports
 }
 
-func (http *Http) Init(test_mode bool, results publisher.Client) error {
+func (http *HTTP) Init(test_mode bool, results publisher.Client) error {
 	http.InitDefaults()
 
 	if !test_mode {
@@ -175,7 +175,7 @@ func (http *Http) Init(test_mode bool, results publisher.Client) error {
 // messageGap is called when a gap of size `nbytes` is found in the
 // tcp stream. Decides if we can ignore the gap or it's a parser error
 // and we need to drop the stream.
-func (http *Http) messageGap(s *HttpStream, nbytes int) (ok bool, complete bool) {
+func (http *HTTP) messageGap(s *stream, nbytes int) (ok bool, complete bool) {
 
 	m := s.message
 	switch s.parseState {
@@ -208,65 +208,65 @@ func (http *Http) messageGap(s *HttpStream, nbytes int) (ok bool, complete bool)
 	return false, false
 }
 
-func (stream *HttpStream) PrepareForNewMessage() {
-	stream.data = stream.data[stream.message.end:]
-	stream.parseState = stateStart
-	stream.parseOffset = 0
-	stream.bodyReceived = 0
-	stream.message = nil
+func (st *stream) PrepareForNewMessage() {
+	st.data = st.data[st.message.end:]
+	st.parseState = stateStart
+	st.parseOffset = 0
+	st.bodyReceived = 0
+	st.message = nil
 }
 
 // Called when the parser has identified the boundary
 // of a message.
-func (http *Http) messageComplete(tcptuple *common.TcpTuple, dir uint8, stream *HttpStream) {
-	msg := stream.data[stream.message.start:stream.message.end]
-	http.hideHeaders(stream.message, msg)
+func (http *HTTP) messageComplete(tcptuple *common.TcpTuple, dir uint8, st *stream) {
+	msg := st.data[st.message.start:st.message.end]
+	http.hideHeaders(st.message, msg)
 
-	http.handleHttp(stream.message, tcptuple, dir, msg)
+	http.handleHttp(st.message, tcptuple, dir, msg)
 
 	// and reset message
-	stream.PrepareForNewMessage()
+	st.PrepareForNewMessage()
 }
 
-func (http *Http) ConnectionTimeout() time.Duration {
+func (http *HTTP) ConnectionTimeout() time.Duration {
 	return http.transactionTimeout
 }
 
-func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
+func (http *HTTP) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	dir uint8, private protos.ProtocolData) protos.ProtocolData {
 
 	defer logp.Recover("ParseHttp exception")
 
 	detailedf("Payload received: [%s]", pkt.Payload)
 
-	priv := httpPrivateData{}
+	priv := httpConnectionData{}
 	if private != nil {
 		var ok bool
-		priv, ok = private.(httpPrivateData)
+		priv, ok = private.(httpConnectionData)
 		if !ok {
-			priv = httpPrivateData{}
+			priv = httpConnectionData{}
 		}
 	}
 
-	if priv.Data[dir] == nil {
-		priv.Data[dir] = &HttpStream{
+	if priv.Streams[dir] == nil {
+		priv.Streams[dir] = &stream{
 			tcptuple: tcptuple,
 			data:     pkt.Payload,
-			message:  &HttpMessage{Ts: pkt.Ts},
+			message:  &message{Ts: pkt.Ts},
 		}
 
 	} else {
 		// concatenate bytes
-		priv.Data[dir].data = append(priv.Data[dir].data, pkt.Payload...)
-		if len(priv.Data[dir].data) > tcp.TCP_MAX_DATA_IN_STREAM {
+		priv.Streams[dir].data = append(priv.Streams[dir].data, pkt.Payload...)
+		if len(priv.Streams[dir].data) > tcp.TCP_MAX_DATA_IN_STREAM {
 			debugf("Stream data too large, dropping TCP stream")
-			priv.Data[dir] = nil
+			priv.Streams[dir] = nil
 			return priv
 		}
 	}
-	stream := priv.Data[dir]
+	stream := priv.Streams[dir]
 	if stream.message == nil {
-		stream.message = &HttpMessage{Ts: pkt.Ts}
+		stream.message = &message{Ts: pkt.Ts}
 	}
 
 	parser := newParser(&http.parserConfig)
@@ -274,7 +274,7 @@ func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	if !ok {
 		// drop this tcp stream. Will retry parsing with the next
 		// segment in it
-		priv.Data[dir] = nil
+		priv.Streams[dir] = nil
 		return priv
 	}
 
@@ -286,21 +286,21 @@ func (http *Http) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	return priv
 }
 
-func (http *Http) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (http *HTTP) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 
 	if private == nil {
 		return private
 	}
-	httpData, ok := private.(httpPrivateData)
+	httpData, ok := private.(httpConnectionData)
 	if !ok {
 		return private
 	}
-	if httpData.Data[dir] == nil {
+	if httpData.Streams[dir] == nil {
 		return httpData
 	}
 
-	stream := httpData.Data[dir]
+	stream := httpData.Streams[dir]
 
 	// send whatever data we got so far as complete. This
 	// is needed for the HTTP/1.0 without Content-Length situation.
@@ -323,7 +323,7 @@ func (http *Http) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 
 // Called when a gap of nbytes bytes is found in the stream (due to
 // packet loss).
-func (http *Http) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (http *HTTP) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 
 	defer logp.Recover("GapInStream(http) exception")
@@ -331,11 +331,11 @@ func (http *Http) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	if private == nil {
 		return private, false
 	}
-	httpData, ok := private.(httpPrivateData)
+	httpData, ok := private.(httpConnectionData)
 	if !ok {
 		return private, false
 	}
-	stream := httpData.Data[dir]
+	stream := httpData.Streams[dir]
 	if stream == nil || stream.message == nil {
 		// nothing to do
 		return private, false
@@ -345,7 +345,7 @@ func (http *Http) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	detailedf("messageGap returned ok=%v complete=%v", ok, complete)
 	if !ok {
 		// on errors, drop stream
-		httpData.Data[dir] = nil
+		httpData.Streams[dir] = nil
 		return httpData, true
 	}
 
@@ -358,10 +358,10 @@ func (http *Http) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	return private, false
 }
 
-func (http *Http) handleHttp(m *HttpMessage, tcptuple *common.TcpTuple,
+func (http *HTTP) handleHttp(m *message, tcptuple *common.TcpTuple,
 	dir uint8, raw_msg []byte) {
 
-	m.TcpTuple = *tcptuple
+	m.TCPTuple = *tcptuple
 	m.Direction = dir
 	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
 	m.Raw = raw_msg
@@ -373,31 +373,31 @@ func (http *Http) handleHttp(m *HttpMessage, tcptuple *common.TcpTuple,
 	}
 }
 
-func (http *Http) receivedHttpRequest(msg *HttpMessage) {
+func (http *HTTP) receivedHttpRequest(msg *message) {
 
-	trans := http.getTransaction(msg.TcpTuple.Hashable())
+	trans := http.getTransaction(msg.TCPTuple.Hashable())
 	if trans != nil {
-		if len(trans.Http) != 0 {
+		if len(trans.HTTP) != 0 {
 			logp.Warn("Two requests without a response. Dropping old request")
 		}
 	} else {
-		trans = &HttpTransaction{Type: "http", tuple: msg.TcpTuple}
-		http.transactions.Put(msg.TcpTuple.Hashable(), trans)
+		trans = &transaction{Type: "http", tuple: msg.TCPTuple}
+		http.transactions.Put(msg.TCPTuple.Hashable(), trans)
 	}
 
-	debugf("Received request with tuple: %s", msg.TcpTuple)
+	debugf("Received request with tuple: %s", msg.TCPTuple)
 
 	trans.ts = msg.Ts
 	trans.Ts = int64(trans.ts.UnixNano() / 1000)
 	trans.JsTs = msg.Ts
 	trans.Src = common.Endpoint{
-		Ip:   msg.TcpTuple.Src_ip.String(),
-		Port: msg.TcpTuple.Src_port,
+		Ip:   msg.TCPTuple.Src_ip.String(),
+		Port: msg.TCPTuple.Src_port,
 		Proc: string(msg.CmdlineTuple.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   msg.TcpTuple.Dst_ip.String(),
-		Port: msg.TcpTuple.Dst_port,
+		Ip:   msg.TCPTuple.Dst_ip.String(),
+		Port: msg.TCPTuple.Dst_port,
 		Proc: string(msg.CmdlineTuple.Dst),
 	}
 	if msg.Direction == tcp.TcpDirectionReverse {
@@ -406,19 +406,19 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 
 	// save Raw message
 	if http.SendRequest {
-		trans.Request_raw = string(http.cutMessageBody(msg))
+		trans.RequestRaw = string(http.cutMessageBody(msg))
 	}
 
 	trans.Method = msg.Method
-	trans.RequestUri = msg.RequestUri
+	trans.RequestURI = msg.RequestURI
 	trans.BytesIn = msg.Size
 	trans.Notes = msg.Notes
 
-	trans.Http = common.MapStr{}
+	trans.HTTP = common.MapStr{}
 
 	if http.parserConfig.SendHeaders {
 		if !http.SplitCookie {
-			trans.Http["request_headers"] = msg.Headers
+			trans.HTTP["request_headers"] = msg.Headers
 		} else {
 			hdrs := common.MapStr{}
 			for name, value := range msg.Headers {
@@ -429,11 +429,11 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 				}
 			}
 
-			trans.Http["request_headers"] = hdrs
+			trans.HTTP["request_headers"] = hdrs
 		}
 	}
 
-	trans.Real_ip = msg.Real_ip
+	trans.RealIP = msg.RealIP
 
 	var err error
 	trans.Path, trans.Params, err = http.extractParameters(msg, msg.Raw)
@@ -442,10 +442,10 @@ func (http *Http) receivedHttpRequest(msg *HttpMessage) {
 	}
 }
 
-func (http *Http) receivedHttpResponse(msg *HttpMessage) {
+func (http *HTTP) receivedHttpResponse(msg *message) {
 
 	// we need to search the request first.
-	tuple := msg.TcpTuple
+	tuple := msg.TCPTuple
 
 	debugf("Received response with tuple: %s", tuple)
 
@@ -455,7 +455,7 @@ func (http *Http) receivedHttpResponse(msg *HttpMessage) {
 		return
 	}
 
-	if trans.Http == nil {
+	if trans.HTTP == nil {
 		logp.Warn("Response without a known request. Ignoring.")
 		return
 	}
@@ -484,23 +484,23 @@ func (http *Http) receivedHttpResponse(msg *HttpMessage) {
 	}
 
 	trans.BytesOut = msg.Size
-	trans.Http.Update(response)
+	trans.HTTP.Update(response)
 	trans.Notes = append(trans.Notes, msg.Notes...)
 
 	trans.ResponseTime = int32(msg.Ts.Sub(trans.ts).Nanoseconds() / 1e6) // resp_time in milliseconds
 
 	// save Raw message
 	if http.SendResponse {
-		trans.Response_raw = string(http.cutMessageBody(msg))
+		trans.ResponseRaw = string(http.cutMessageBody(msg))
 	}
 
 	http.publishTransaction(trans)
 	http.transactions.Delete(trans.tuple.Hashable())
 
-	debugf("HTTP transaction completed: %s\n", trans.Http)
+	debugf("HTTP transaction completed: %s\n", trans.HTTP)
 }
 
-func (http *Http) publishTransaction(t *HttpTransaction) {
+func (http *HTTP) publishTransaction(t *transaction) {
 
 	if http.results == nil {
 		return
@@ -509,7 +509,7 @@ func (http *Http) publishTransaction(t *HttpTransaction) {
 	event := common.MapStr{}
 
 	event["type"] = "http"
-	code := t.Http["code"].(uint16)
+	code := t.HTTP["code"].(uint16)
 	if code < 400 {
 		event["status"] = common.OK_STATUS
 	} else {
@@ -517,14 +517,14 @@ func (http *Http) publishTransaction(t *HttpTransaction) {
 	}
 	event["responsetime"] = t.ResponseTime
 	if http.SendRequest {
-		event["request"] = t.Request_raw
+		event["request"] = t.RequestRaw
 	}
 	if http.SendResponse {
-		event["response"] = t.Response_raw
+		event["response"] = t.ResponseRaw
 	}
-	event["http"] = t.Http
-	if len(t.Real_ip) > 0 {
-		event["real_ip"] = t.Real_ip
+	event["http"] = t.HTTP
+	if len(t.RealIP) > 0 {
+		event["real_ip"] = t.RealIP
 	}
 	event["method"] = t.Method
 	event["path"] = t.Path
@@ -567,7 +567,7 @@ func parseCookieValue(raw string) string {
 	return raw
 }
 
-func (http *Http) cutMessageBody(m *HttpMessage) []byte {
+func (http *HTTP) cutMessageBody(m *message) []byte {
 	cutMsg := []byte{}
 
 	// add headers always
@@ -575,8 +575,8 @@ func (http *Http) cutMessageBody(m *HttpMessage) []byte {
 
 	// add body
 	if len(m.ContentType) == 0 || http.shouldIncludeInBody(m.ContentType) {
-		if len(m.chunked_body) > 0 {
-			cutMsg = append(cutMsg, m.chunked_body...)
+		if len(m.chunkedBody) > 0 {
+			cutMsg = append(cutMsg, m.chunkedBody...)
 		} else {
 			debugf("Body to include: [%s]", m.Raw[m.bodyOffset:])
 			cutMsg = append(cutMsg, m.Raw[m.bodyOffset:]...)
@@ -586,7 +586,7 @@ func (http *Http) cutMessageBody(m *HttpMessage) []byte {
 	return cutMsg
 }
 
-func (http *Http) shouldIncludeInBody(contenttype string) bool {
+func (http *HTTP) shouldIncludeInBody(contenttype string) bool {
 	includedBodies := config.ConfigSingleton.Protocols.Http.Include_body_for
 	for _, include := range includedBodies {
 		if strings.Contains(contenttype, include) {
@@ -598,7 +598,7 @@ func (http *Http) shouldIncludeInBody(contenttype string) bool {
 	return false
 }
 
-func (http *Http) hideHeaders(m *HttpMessage, msg []byte) {
+func (http *HTTP) hideHeaders(m *message, msg []byte) {
 
 	if m.IsRequest {
 		// byte64 != encryption, so obscure it in headers in case of Basic Authentication
@@ -644,7 +644,7 @@ func (http *Http) hideHeaders(m *HttpMessage, msg []byte) {
 	}
 }
 
-func (http *Http) hideSecrets(values url.Values) url.Values {
+func (http *HTTP) hideSecrets(values url.Values) url.Values {
 
 	params := url.Values{}
 	for key, array := range values {
@@ -662,10 +662,10 @@ func (http *Http) hideSecrets(values url.Values) url.Values {
 // extractParameters parses the URL and the form parameters and replaces the secrets
 // with the string xxxxx. The parameters containing secrets are defined in http.Hide_secrets.
 // Returns the Request URI path and the (ajdusted) parameters.
-func (http *Http) extractParameters(m *HttpMessage, msg []byte) (path string, params string, err error) {
+func (http *HTTP) extractParameters(m *message, msg []byte) (path string, params string, err error) {
 	var values url.Values
 
-	u, err := url.Parse(m.RequestUri)
+	u, err := url.Parse(m.RequestURI)
 	if err != nil {
 		return
 	}
@@ -691,7 +691,7 @@ func (http *Http) extractParameters(m *HttpMessage, msg []byte) (path string, pa
 	return
 }
 
-func (http *Http) isSecretParameter(key string) bool {
+func (http *HTTP) isSecretParameter(key string) bool {
 
 	for _, keyword := range http.HideKeywords {
 		if strings.ToLower(key) == keyword {

--- a/protos/http/http_parser.go
+++ b/protos/http/http_parser.go
@@ -1,0 +1,414 @@
+package http
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
+)
+
+// Http Message
+type HttpMessage struct {
+	Ts               time.Time
+	hasContentLength bool
+	headerOffset     int
+	bodyOffset       int
+	version          version
+	connection       string
+	chunked_length   int
+	chunked_body     []byte
+
+	IsRequest    bool
+	TcpTuple     common.TcpTuple
+	CmdlineTuple *common.CmdlineTuple
+	Direction    uint8
+	//Request Info
+	FirstLine    string
+	RequestUri   string
+	Method       string
+	StatusCode   uint16
+	StatusPhrase string
+	Real_ip      string
+	// Http Headers
+	ContentLength    int
+	ContentType      string
+	TransferEncoding string
+	Headers          map[string]string
+	Body             string
+	Size             uint64
+	//Raw Data
+	Raw []byte
+
+	Notes []string
+
+	//Timing
+	start int
+	end   int
+}
+
+type version struct {
+	major uint8
+	minor uint8
+}
+
+type parser struct {
+	config *parserConfig
+}
+
+type parserConfig struct {
+	RealIPHeader     string
+	SendHeaders      bool
+	SendAllHeaders   bool
+	HeadersWhitelist map[string]bool
+}
+
+func newParser(config *parserConfig) *parser {
+	return &parser{config: config}
+}
+
+func (parser *parser) parse(s *HttpStream) (bool, bool) {
+	m := s.message
+
+	for s.parseOffset < len(s.data) {
+		switch s.parseState {
+		case stateStart:
+			if cont, ok, complete := parser.parseHTTPLine(s, m); !cont {
+				return ok, complete
+			}
+		case stateHeaders:
+			if cont, ok, complete := parser.parseHeaders(s, m); !cont {
+				return ok, complete
+			}
+		case stateBody:
+			return parser.parseBody(s, m)
+		case stateBodyChunkedStart:
+			if cont, ok, complete := parser.parseBodyChunkedStart(s, m); !cont {
+				return ok, complete
+			}
+		case stateBodyChunked:
+			if cont, ok, complete := parser.parseBodyChunked(s, m); !cont {
+				return ok, complete
+			}
+		case stateBodyChunkedWaitFinalCRLF:
+			return parser.parseBodyChunkedWaitFinalCRLF(s, m)
+		}
+	}
+
+	return true, false
+}
+
+func (*parser) parseHTTPLine(s *HttpStream, m *HttpMessage) (cont, ok, complete bool) {
+	m.start = s.parseOffset
+	i := bytes.Index(s.data[s.parseOffset:], []byte("\r\n"))
+	if i == -1 {
+		return false, true, false
+	}
+
+	// Very basic tests on the first line. Just to check that
+	// we have what looks as an HTTP message
+	var version []byte
+	var err error
+	fline := s.data[s.parseOffset:i]
+	if len(fline) < 8 {
+		debugf("First line too small")
+		return false, false, false
+	}
+	if bytes.Equal(fline[0:5], []byte("HTTP/")) {
+		//RESPONSE
+		m.IsRequest = false
+		version = fline[5:8]
+		m.StatusCode, m.StatusPhrase, err = parseResponseStatus(fline[9:])
+		if err != nil {
+			logp.Warn("Failed to understand HTTP response status: %s", fline[9:])
+			return false, false, false
+		}
+		debugf("HTTP status_code=%d, status_phrase=%s", m.StatusCode, m.StatusPhrase)
+
+	} else {
+		// REQUEST
+		slices := bytes.Fields(fline)
+		if len(slices) != 3 {
+			debugf("Couldn't understand HTTP request: %s", fline)
+			return false, false, false
+		}
+
+		m.Method = string(slices[0])
+		m.RequestUri = string(slices[1])
+
+		if bytes.Equal(slices[2][:5], []byte("HTTP/")) {
+			m.IsRequest = true
+			version = slices[2][5:]
+			m.FirstLine = string(fline)
+		} else {
+			debugf("Couldn't understand HTTP version: %s", fline)
+			return false, false, false
+		}
+		debugf("HTTP Method=%s, RequestUri=%s", m.Method, m.RequestUri)
+	}
+
+	m.version.major, m.version.minor, err = parseVersion(version)
+	if err != nil {
+		debugf("Failed to understand HTTP version: %v", version)
+		m.version.major = 1
+		m.version.minor = 0
+	}
+	debugf("HTTP version %d.%d", m.version.major, m.version.minor)
+
+	// ok so far
+	s.parseOffset = i + 2
+	m.headerOffset = s.parseOffset
+	s.parseState = stateHeaders
+
+	return true, true, true
+}
+
+func parseResponseStatus(s []byte) (uint16, string, error) {
+	debugf("parseResponseStatus: %s", s)
+
+	p := bytes.Index(s, []byte(" "))
+	if p == -1 {
+		return 0, "", errors.New("Not beeing able to identify status code")
+	}
+
+	code, _ := strconv.Atoi(string(s[0:p]))
+
+	p = bytes.LastIndex(s, []byte(" "))
+	if p == -1 {
+		return uint16(code), "", errors.New("Not beeing able to identify status code")
+	}
+	phrase := s[p+1:]
+	return uint16(code), string(phrase), nil
+}
+
+func parseVersion(s []byte) (uint8, uint8, error) {
+	if len(s) < 3 {
+		return 0, 0, errors.New("Invalid version")
+	}
+
+	major, _ := strconv.Atoi(string(s[0]))
+	minor, _ := strconv.Atoi(string(s[2]))
+
+	return uint8(major), uint8(minor), nil
+}
+
+func (parser *parser) parseHeaders(s *HttpStream, m *HttpMessage) (cont, ok, complete bool) {
+	if len(s.data)-s.parseOffset >= 2 &&
+		bytes.Equal(s.data[s.parseOffset:s.parseOffset+2], []byte("\r\n")) {
+		// EOH
+		s.parseOffset += 2
+		m.bodyOffset = s.parseOffset
+
+		if !m.IsRequest && ((100 <= m.StatusCode && m.StatusCode < 200) || m.StatusCode == 204 || m.StatusCode == 304) {
+			//response with a 1xx, 204 , or 304 status  code is always terminated
+			// by the first empty line after the  header fields
+			debugf("Terminate response, status code %d", m.StatusCode)
+			m.end = s.parseOffset
+			m.Size = uint64(m.end - m.start)
+			return false, true, true
+		}
+
+		if m.TransferEncoding == "chunked" {
+			// support for HTTP/1.1 Chunked transfer
+			// Transfer-Encoding overrides the Content-Length
+			debugf("Read chunked body")
+			s.parseState = stateBodyChunkedStart
+			return true, true, true
+		}
+
+		if m.ContentLength == 0 && (m.IsRequest || m.hasContentLength) {
+			debugf("Empty content length, ignore body")
+			// Ignore body for request that contains a message body but not a Content-Length
+			m.end = s.parseOffset
+			m.Size = uint64(m.end - m.start)
+			return false, true, true
+		}
+
+		debugf("Read body")
+		s.parseState = stateBody
+	} else {
+		ok, hfcomplete, offset := parser.parseHeader(m, s.data[s.parseOffset:])
+		if !ok {
+			return false, false, false
+		}
+		if !hfcomplete {
+			return false, true, false
+		}
+		s.parseOffset += offset
+	}
+	return true, true, true
+}
+
+func (parser *parser) parseHeader(m *HttpMessage, data []byte) (bool, bool, int) {
+	if m.Headers == nil {
+		m.Headers = make(map[string]string)
+	}
+	i := bytes.Index(data, []byte(":"))
+	if i == -1 {
+		// Expected \":\" in headers. Assuming incomplete"
+		return true, false, 0
+	}
+
+	config := parser.config
+
+	detailedf("Data: %s", data)
+	detailedf("Header: %s", data[:i])
+
+	// skip folding line
+	for p := i + 1; p < len(data); {
+		q := bytes.Index(data[p:], []byte("\r\n"))
+		if q == -1 {
+			// Assuming incomplete
+			return true, false, 0
+		}
+		p += q
+		detailedf("HV: %s\n", data[i+1:p])
+		if len(data) > p && (data[p+1] == ' ' || data[p+1] == '\t') {
+			p = p + 2
+		} else {
+			headerName := strings.ToLower(string(data[:i]))
+			headerVal := string(bytes.Trim(data[i+1:p], " \t"))
+			debugf("Header: '%s' Value: '%s'\n", headerName, headerVal)
+
+			// Headers we need for parsing. Make sure we always
+			// capture their value
+			if headerName == "content-length" {
+				m.ContentLength, _ = strconv.Atoi(headerVal)
+				m.hasContentLength = true
+			} else if headerName == "content-type" {
+				m.ContentType = headerVal
+			} else if headerName == "transfer-encoding" {
+				m.TransferEncoding = headerVal
+			} else if headerName == "connection" {
+				m.connection = headerVal
+			}
+			if len(config.RealIPHeader) > 0 && headerName == config.RealIPHeader {
+				m.Real_ip = headerVal
+			}
+
+			if config.SendHeaders {
+				if !config.SendAllHeaders {
+					_, exists := config.HeadersWhitelist[headerName]
+					if !exists {
+						return true, true, p + 2
+					}
+				}
+				if val, ok := m.Headers[headerName]; ok {
+					m.Headers[headerName] = val + ", " + headerVal
+				} else {
+					m.Headers[headerName] = headerVal
+				}
+			}
+
+			return true, true, p + 2
+		}
+	}
+
+	return true, false, len(data)
+}
+
+func (*parser) parseBody(s *HttpStream, m *HttpMessage) (ok, complete bool) {
+	debugf("eat body: %d", s.parseOffset)
+	if !m.hasContentLength && (m.connection == "close" ||
+		(isVersion(m.version, 1, 0) && m.connection != "keep-alive")) {
+
+		// HTTP/1.0 no content length. Add until the end of the connection
+		debugf("close connection, %d", len(s.data)-s.parseOffset)
+		s.bodyReceived += (len(s.data) - s.parseOffset)
+		m.ContentLength += (len(s.data) - s.parseOffset)
+		s.parseOffset = len(s.data)
+		return true, false
+	} else if len(s.data[s.parseOffset:]) >= m.ContentLength-s.bodyReceived {
+		s.parseOffset += (m.ContentLength - s.bodyReceived)
+		m.end = s.parseOffset
+		m.Size = uint64(m.end - m.start)
+		return true, true
+	} else {
+		s.bodyReceived += (len(s.data) - s.parseOffset)
+		s.parseOffset = len(s.data)
+		debugf("bodyReceived: %d", s.bodyReceived)
+		return true, false
+	}
+}
+
+func (*parser) parseBodyChunkedStart(s *HttpStream, m *HttpMessage) (cont, ok, complete bool) {
+	// read hexa length
+	i := bytes.Index(s.data[s.parseOffset:], []byte("\r\n"))
+	if i == -1 {
+		return false, true, false
+	}
+	line := string(s.data[s.parseOffset : s.parseOffset+i])
+	_, err := fmt.Sscanf(line, "%x", &m.chunked_length)
+	if err != nil {
+		logp.Warn("Failed to understand chunked body start line")
+		return false, false, false
+	}
+
+	s.parseOffset += i + 2 //+ \r\n
+	if m.chunked_length == 0 {
+		if len(s.data[s.parseOffset:]) < 2 {
+			s.parseState = stateBodyChunkedWaitFinalCRLF
+			return false, true, false
+		}
+		if s.data[s.parseOffset] != '\r' || s.data[s.parseOffset+1] != '\n' {
+			logp.Warn("Expected CRLF sequence at end of message")
+			return false, false, false
+		}
+		s.parseOffset += 2 // skip final CRLF
+
+		m.end = s.parseOffset
+		m.Size = uint64(m.end - m.start)
+		return false, true, true
+	}
+	s.bodyReceived = 0
+	s.parseState = stateBodyChunked
+
+	return true, true, false
+}
+
+func (*parser) parseBodyChunked(s *HttpStream, m *HttpMessage) (cont, ok, complete bool) {
+
+	if len(s.data[s.parseOffset:]) >= m.chunked_length-s.bodyReceived+2 /*\r\n*/ {
+		// Received more data than expected
+		m.chunked_body = append(m.chunked_body, s.data[s.parseOffset:s.parseOffset+m.chunked_length-s.bodyReceived]...)
+		s.parseOffset += (m.chunked_length - s.bodyReceived + 2 /*\r\n*/)
+		m.ContentLength += m.chunked_length
+		s.parseState = stateBodyChunkedStart
+		return true, true, false
+	}
+
+	if len(s.data[s.parseOffset:]) >= m.chunked_length-s.bodyReceived {
+		// we need need to wait for the +2, else we can crash on next call
+		return false, true, false
+	}
+
+	// Received less data than expected
+	m.chunked_body = append(m.chunked_body, s.data[s.parseOffset:]...)
+	s.bodyReceived += (len(s.data) - s.parseOffset)
+	s.parseOffset = len(s.data)
+	return false, true, false
+}
+
+func (*parser) parseBodyChunkedWaitFinalCRLF(s *HttpStream, m *HttpMessage) (ok, complete bool) {
+	if len(s.data[s.parseOffset:]) < 2 {
+		return true, false
+	}
+
+	if s.data[s.parseOffset] != '\r' || s.data[s.parseOffset+1] != '\n' {
+		logp.Warn("Expected CRLF sequence at end of message")
+		return false, false
+	}
+
+	s.parseOffset += 2 // skip final CRLF
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+	return true, true
+}
+
+func isVersion(v version, major, minor uint8) bool {
+	return v.major == major && v.minor == minor
+}

--- a/protos/http/http_test.go
+++ b/protos/http/http_test.go
@@ -26,7 +26,7 @@ var testParserConfig = parserConfig{}
 
 func newTestParser(http *HTTP, payloads ...string) *testParser {
 	if http == nil {
-		http = HttpModForTests()
+		http = httpModForTests()
 	}
 	tp := &testParser{
 		http:     http,
@@ -48,9 +48,9 @@ func (tp *testParser) parse() (*message, bool, bool) {
 	return st.message, ok, complete
 }
 
-func HttpModForTests() *HTTP {
+func httpModForTests() *HTTP {
 	var http HTTP
-	results := publisher.ChanClient{make(chan common.MapStr, 10)}
+	results := publisher.ChanClient{Channel: make(chan common.MapStr, 10)}
 	http.Init(true, results)
 	return &http
 }
@@ -114,7 +114,7 @@ func TestHttpParser_simpleResponseCaseInsensitive(t *testing.T) {
 }
 
 func TestHttpParser_simpleRequest(t *testing.T) {
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
 
@@ -145,7 +145,7 @@ func TestHttpParser_simpleRequest(t *testing.T) {
 }
 
 func TestHttpParser_Request_ContentLength_0(t *testing.T) {
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
 
@@ -186,7 +186,7 @@ func TestHttpParser_splitResponse(t *testing.T) {
 }
 
 func TestHttpParser_splitResponse_midHeaderName(t *testing.T) {
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
 
@@ -584,7 +584,7 @@ func TestHttpParser_censorPasswordURL(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.HideKeywords = []string{"password", "pass"}
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
@@ -622,7 +622,7 @@ func TestHttpParser_censorPasswordPOST(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.HideKeywords = []string{"password"}
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
@@ -652,7 +652,7 @@ func TestHttpParser_censorPasswordGET(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.HideKeywords = []string{"password"}
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
@@ -699,7 +699,7 @@ func TestHttpParser_RedactAuthorization(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.RedactAuthorization = true
 	http.parserConfig.SendHeaders = true
 	http.parserConfig.SendAllHeaders = true
@@ -750,7 +750,7 @@ func TestHttpParser_RedactAuthorization(t *testing.T) {
 
 func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.RedactAuthorization = true
 	http.parserConfig.SendHeaders = false
 	http.parserConfig.SendAllHeaders = false
@@ -786,7 +786,7 @@ func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
 
 func TestHttpParser_RedactAuthorization_Proxy_raw(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	http.RedactAuthorization = true
 	http.parserConfig.SendHeaders = false
 	http.parserConfig.SendAllHeaders = false
@@ -814,8 +814,8 @@ func TestHttpParser_RedactAuthorization_Proxy_raw(t *testing.T) {
 		t.Errorf("Expecting a complete message")
 	}
 
-	raw_message_obscured := bytes.Index(msg, []byte("uthorization:*"))
-	if raw_message_obscured < 0 {
+	rawMessageObscured := bytes.Index(msg, []byte("uthorization:*"))
+	if rawMessageObscured < 0 {
 		t.Errorf("Failed to redact proxy-authorization header: " + string(msg[:]))
 	}
 }
@@ -900,7 +900,7 @@ func Test_splitCookiesHeader(t *testing.T) {
 // headers, drop the stream.
 func Test_gap_in_headers(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 
 	data1 := []byte("HTTP/1.1 200 OK\r\n" +
 		"Date: Tue, 14 Aug 2012 22:31:45 GMT\r\n" +
@@ -922,7 +922,7 @@ func Test_gap_in_headers(t *testing.T) {
 // parts of the body, it's ok.
 func Test_gap_in_body(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 
 	data1 := []byte("HTTP/1.1 200 OK\r\n" +
 		"Date: Tue, 14 Aug 2012 22:31:45 GMT\r\n" +
@@ -955,7 +955,7 @@ func Test_gap_in_body(t *testing.T) {
 // parts of the body, it's ok.
 func Test_gap_in_body_http1dot0(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 
 	data1 := []byte("HTTP/1.0 200 OK\r\n" +
 		"Date: Tue, 14 Aug 2012 22:31:45 GMT\r\n" +
@@ -980,7 +980,7 @@ func Test_gap_in_body_http1dot0(t *testing.T) {
 
 }
 
-func testTcpTuple() *common.TcpTuple {
+func testCreateTCPTuple() *common.TcpTuple {
 	t := &common.TcpTuple{
 		Ip_length: 4,
 		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
@@ -1007,7 +1007,7 @@ func Test_gap_in_body_http1dot0_fin(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http",
 			"httpdetailed"})
 	}
-	http := HttpModForTests()
+	http := httpModForTests()
 
 	data1 := []byte("GET / HTTP/1.0\r\n\r\n")
 
@@ -1023,7 +1023,7 @@ func Test_gap_in_body_http1dot0_fin(t *testing.T) {
 		"\r\n" +
 		"xxxxxxxxxxxxxxxxxxxx")
 
-	tcptuple := testTcpTuple()
+	tcptuple := testCreateTCPTuple()
 	req := protos.Packet{Payload: data1}
 	resp := protos.Packet{Payload: data2}
 
@@ -1048,7 +1048,7 @@ func Test_gap_in_body_http1dot0_fin(t *testing.T) {
 
 func TestHttp_configsSettingAll(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	config := new(config.Http)
 
 	// Assign config vars
@@ -1061,11 +1061,11 @@ func TestHttp_configsSettingAll(t *testing.T) {
 	config.Redact_authorization = &trueVar
 	config.Send_all_headers = &trueVar
 	config.Split_cookie = &trueVar
-	realIpHeader := "X-Forwarded-For"
-	config.Real_ip_header = &realIpHeader
+	realIPHeader := "X-Forwarded-For"
+	config.Real_ip_header = &realIPHeader
 
 	// Set config
-	http.SetFromConfig(*config)
+	http.setFromConfig(*config)
 
 	// Check if http config is set correctly
 	assert.Equal(t, config.Ports, http.Ports)
@@ -1082,14 +1082,14 @@ func TestHttp_configsSettingAll(t *testing.T) {
 
 func TestHttp_configsSettingHeaders(t *testing.T) {
 
-	http := HttpModForTests()
+	http := httpModForTests()
 	config := new(config.Http)
 
 	// Assign config vars
 	config.Send_headers = []string{"a", "b", "c"}
 
 	// Set config
-	http.SetFromConfig(*config)
+	http.setFromConfig(*config)
 
 	// Check if http config is set correctly
 	assert.True(t, http.parserConfig.SendHeaders)


### PR DESCRIPTION
This PR is minor cleanup of http module preparing for potentially new features to be added: potentially #404 and HTTP pipelining. HTTP pipelining support will improve correlation (pipelining more common in REST APIs - e.g. CouchDB or Elasticsearch) + simplify and separate main module from transaction handling like in redis or memcache module do in generating transactions only for correlated messages. 

This PR applies some module internal renamings + moves message parser into http_parser.go